### PR TITLE
chore: commit to scope A (backend-only library, no WASM)

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,6 +1,6 @@
 # haskell-gamechanger Constitution
 
-**Version:** 0.2.0 · **Ratified:** 2026-04-18 · **Status:** Understanding phase
+**Version:** 0.3.0 · **Ratified:** 2026-04-18 · **Status:** Understanding phase
 
 This project's current purpose is **to understand the GameChanger
 wallet protocol thoroughly before writing any Haskell code against it**.
@@ -200,30 +200,36 @@ results — "no public audit found as of 2026-04-18" is valid content).
 
 ## 8. What This Repository Will Ship (Eventually)
 
-The eventual scope of a Haskell implementation rests on this
-constitution:
+This library is a **backend library for GameChanger integrations**.
+It targets topologies [6.2](#62-client--backend-callback) and
+[6.3](#63-backend-only-issuer) — the ones where a Haskell service
+authors scripts, dispatches them to a user's browser via URL or QR,
+and receives signed results via a callback. Topology
+[6.1](#61-client-only) (fully in-browser) is **out of scope**; an
+integrator who wants client-only behavior implements the browser
+side in whatever language suits them, against the published
+`GameChanger.Script` JSON schema.
+
+The eventual scope:
 
 - A **pure Haskell model** of the script DSL
   (`GameChanger.Script`, Aeson records), the encoding pipeline, the
-  export descriptors, and the callback payload shape. This is the
-  low-level, JSON-faithful layer.
+  export descriptors, and the callback payload shape. The JSON
+  schema emitted here is the **published boundary** for non-Haskell
+  clients.
 - A **monadic intent eDSL** (`GameChanger.Intent`) built on
-  `Control.Monad.Operational`. Users compose scripts in `do`-notation
-  with typed bindings and action combinators; a pure compiler emits
-  the corresponding `GameChanger.Script` JSON with properly-wired
-  `{get(...)}` references. See §11.
+  `Control.Monad.Operational` — see §11 — with a pure,
+  deterministic compiler to `GameChanger.Script`.
 - A **URL builder** that takes a typed script (or a compiled
   `Intent`) and returns a resolver URL, plus a **QR renderer** for
   out-of-band delivery.
 - A **callback receiver** (servant or warp) for the `post` export
-  that validates sessions, parses CBOR, and hands signed transactions
-  to an existing cardano-api / node-clients submission path.
-- A **WASM build** of the eDSL + encoder. Same library, two
-  deployment targets: native in a Haskell backend (topologies 6.2
-  and 6.3) and in-browser (topology 6.1, driving a page that opens
-  the wallet). First-class target once the eDSL surface stabilizes.
-- A **small CLI** that wraps the native layers — useful for manual
-  preprod testing and as an integration smoke-test.
+  that validates sessions, parses CBOR strictly, and hands signed
+  transactions to an existing cardano-api / node-clients
+  submission path.
+- A **small CLI** (`hgc`) that wraps the above — manual preprod
+  testing and integration smoke-tests, including an end-to-end
+  driver that runs against the real beta wallet.
 
 Explicitly out of scope:
 
@@ -233,14 +239,26 @@ Explicitly out of scope:
   Haskell-side interpreter for `buildTx`, `signTx`, or any other
   action.
 - Reimplementing any part of the wallet.
+- **Topology 6.1 (client-only) and any in-browser Haskell
+  deployment.** The `cardano-api` / `cardano-ledger` dependency
+  chain needed for CBOR-level transaction handling does not
+  WASM-compile today, and this library's value concentrates on the
+  native side that already talks to `cardano-node`. Projects that
+  need typed script construction in the browser consume the
+  published JSON schema from TypeScript, PureScript, or similar.
+- A WASM build of this library. See above.
 
 ## 11. Intent eDSL (Design Sketch)
 
-The eDSL is a **surface**, not a **semantics**. Every script it
-emits must be expressible by hand-written JSON against the same
-wallet. It may rule out malformed scripts at compile time; it must
-never rely on post-processing, runtime extension, or wallet
-features beyond the published DSL.
+A typed surface for building GameChanger scripts in Haskell, built
+on `Control.Monad.Operational`. Sits on top of `GameChanger.Script`
+and compiles to the same JSON a hand-written script would produce.
+
+It is a **surface**, not a **semantics**. Every script it emits
+must be expressible by hand-written JSON against the same wallet.
+It may rule out malformed scripts at compile time; it must never
+rely on post-processing, runtime extension, or wallet features
+beyond the published DSL.
 
 ### 11.1 Shape
 
@@ -268,30 +286,43 @@ voteOnProposal addr pid vote = do
   submitTx signed
 ```
 
+Each `<-` is a GameChanger action; each reference to a bound
+variable becomes, after compilation, a `{get('cache.<name>')}`
+expression in the emitted JSON. A typo in wiring no longer
+compiles.
+
+The encoding is `Control.Monad.Operational` deliberately. The
+compiler is a structural fold over the program — it needs to
+pattern-match on each `IntentI` constructor to emit the right
+`run`-block entry — and operational's `view` gives us that
+directly. Typeclass-indexed alternatives (final-tagless) are not
+used in this library.
+
 ### 11.2 Compilation
 
-A pure interpreter folds the `Program` into a `GameChanger.Script`:
+A pure interpreter folds a `Program IntentI a` into a
+`GameChanger.Script`:
 
-- Each primitive becomes a named entry in the `run` block (unique
-  name generated by the compiler).
+- Each primitive becomes a named entry in the `run` block.
+  Compiler-generated names are stable (hash-derived from the
+  program structure).
 - Each monadic bind becomes a `{get('<namespace>.<name>')}`
   template expression feeding the next action's `detail`.
-- The final `pure x` (or the selected return) determines the default
-  `exports` clause; additional exports may be declared with a
-  dedicated combinator (`declareExport`).
+- The final returned value (or a `declareExport` combinator) drives
+  the `exports` clause.
 
 ### 11.3 Invariants
 
-1. **Surface-only.** For every `Intent a`, there exists a handwritten
-   JSON script with identical wallet behavior.
+1. **Surface-only.** For every `Intent a`, there exists a
+   handwritten JSON script with identical wallet behavior.
 2. **Deterministic compilation.** Same `Intent` → same JSON,
    byte-for-byte (stable name generation, sorted keys where
    possible).
 3. **No runtime effects.** Compilation is pure; the compiler never
    performs network IO, signing, or key derivation.
-4. **WASM-neutral.** The compiler compiles identically under
-   native GHC and `wasm32-wasi-ghc`. No platform-specific code in
-   `GameChanger.Intent`.
+4. **Native-only.** The eDSL and its compiler target native GHC
+   against `cardano-api` / `cardano-node-clients`. No WASM target,
+   no browser deployment. See §8.
 
 ## 9. How To Use This Repository (Today)
 
@@ -322,4 +353,4 @@ updates (a) this document, (b) the `docs/` site, and (c) the
 `data/rdf/` ontology together in one vertical commit. All three are
 derivative of the same understanding and must move in lockstep.
 
-**Version:** 0.2.0 | **Ratified:** 2026-04-18 | **Last Amended:** 2026-04-19
+**Version:** 0.3.0 | **Ratified:** 2026-04-18 | **Last Amended:** 2026-04-20

--- a/data/rdf/gamechanger-ontology.ttl
+++ b/data/rdf/gamechanger-ontology.ttl
@@ -148,7 +148,7 @@ gc:SignedResult a owl:Class ;
 
 gc:IntentProgram a owl:Class ;
   rdfs:label "Intent program" ;
-  dcterms:description "A Haskell operational-monad expression in GameChanger.Intent that compiles deterministically to a gc:Script. A surface layer with typed bindings for {get(...)} references and ordinary Haskell combinators for composition; adds no wallet semantics beyond the published DSL." ;
+  dcterms:description "A Haskell expression in GameChanger.Intent, built on Control.Monad.Operational, that compiles deterministically to a gc:Script. A surface layer with typed bindings for {get(...)} references and ordinary Haskell combinators for composition; adds no wallet semantics beyond the published DSL. Native backend only." ;
   rdfs:subClassOf gckind:concept .
 
 gc:compilesTo a owl:ObjectProperty ;

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,6 +51,9 @@ What Haskell cannot do:
 
 ## Where to start
 
+- **Wondering what this library is?** Read [Scope](./scope.md) — a
+  short page on what this library does, what it does not, and why
+  topology 6.1 (client-only) is out of scope.
 - **New to GameChanger?** Read [Protocol](./protocol.md) — it covers
   the script DSL, the encoding pipeline, and export modes.
 - **Planning to integrate?** Read [Integration](./integration.md) —
@@ -60,7 +63,7 @@ What Haskell cannot do:
   published audits.
 - **Designing the Haskell API?** Read
   [Intent eDSL](./intent-dsl.md) — the monadic surface that compiles
-  to GameChanger scripts, deployable natively and as WASM.
+  to GameChanger scripts, native backend only.
 - **Browsing visually?** Open the
   [graph view](https://lambdasistemi.github.io/graph-browser/?repo=lambdasistemi/haskell-gamechanger)
   — the same concepts as a node-link diagram, backed by a

--- a/docs/intent-dsl.md
+++ b/docs/intent-dsl.md
@@ -6,9 +6,14 @@ GameChanger scripts in Haskell. It sits on top of
 compiles down to the same JSON a hand-written script would emit.
 
 It is a **surface, not a semantics.** It does not evaluate wallet
-actions, does not simulate transactions, and does not add any
-capability the protocol does not already support. It only moves
-errors from wallet-execution time to compile time.
+actions, does not simulate transactions, and adds no capability
+beyond the published DSL. It only moves errors from
+wallet-execution time to compile time.
+
+It is **backend-only.** This library does not target the browser.
+See [scope](./scope.md) for why, and
+[Integration §6.2 / §6.3](./integration.md) for the topologies this
+serves.
 
 ## Why an eDSL
 
@@ -23,13 +28,13 @@ non-trivial:
    you copy-paste between scripts. JSON gives no mechanism to
    factor it out.
 
-An eDSL in Haskell, with the right monadic structure, fixes both:
-typed bindings for wiring, and ordinary Haskell functions for
+An eDSL in Haskell, with a monadic structure, fixes both: typed
+bindings for wiring, and ordinary Haskell functions for
 composition.
 
 ## Shape
 
-The underlying machinery is
+The encoding is
 [`Control.Monad.Operational`](https://hackage.haskell.org/package/operational).
 Primitives are a GADT; the monad is `Program`:
 
@@ -57,8 +62,14 @@ voteOnProposal addr pid vote = do
 
 Each `<-` is a GameChanger action name. Each reference to a bound
 variable (`utxos`, `tx`, `signed`) is, after compilation, a
-`{get('cache.<name>')}` reference in the emitted JSON. A typo no
-longer compiles.
+`{get('cache.<name>')}` reference in the emitted JSON. A typo in
+wiring no longer compiles.
+
+Operational is a deliberate choice over typeclass-indexed encodings
+(final-tagless). The compiler pattern-matches on each `IntentI`
+constructor to emit the corresponding `run`-block entry;
+operational's `view` exposes exactly that structure. No typeclass
+surface is introduced.
 
 ## Compilation
 
@@ -79,34 +90,41 @@ produces the same JSON, byte-for-byte.
 
 ## Deployment
 
-The eDSL + encoder build both natively (for Haskell backends) and
-as WASM (for browser pages). The compiler does not perform IO, does
-not touch keys, and has no platform-specific code — so the two
-builds share 100% of the source.
+Native GHC, linked into whatever backend already talks to
+`cardano-node`. No WASM, no browser shim.
 
-This unlocks all three integration topologies from a single
-library:
+```
+┌─────────────────────────────────────────────┐
+│  Your Haskell service (MPFS, MOOG, your app)│
+├─────────────────────────────────────────────┤
+│  haskell-gamechanger                        │
+├─────────────────────────────────────────────┤
+│  cardano-api / cardano-node-clients         │
+└─────────────────────────────────────────────┘
+```
 
-| Topology | Where the eDSL runs | What it emits |
-|---|---|---|
-| Client-only ([§6.1](integration.md#1-client-only)) | In-browser via WASM | Resolver URL for `window.open` |
-| Client + backend callback ([§6.2](integration.md#2-client-backend-callback)) | In the Haskell backend | Resolver URL with a `post` export |
-| Backend-only issuer ([§6.3](integration.md#3-backend-only-issuer)) | In the Haskell backend | Resolver URL, rendered as QR or printed |
+The browser side — the page that opens a resolver URL and receives
+a `return` or drives a `post` — is the integrator's responsibility
+and is not part of this library. `GameChanger.Script`'s JSON
+schema is the published boundary; any language can produce scripts
+that the wallet will accept, and any language can consume the
+published JSON schema to build its own typed surface.
 
 ## Invariants
 
-Recorded formally in the [constitution §11.3](https://github.com/lambdasistemi/haskell-gamechanger/blob/main/.specify/memory/constitution.md):
+Recorded formally in the
+[constitution §11.3](https://github.com/lambdasistemi/haskell-gamechanger/blob/main/.specify/memory/constitution.md):
 
 1. **Surface-only.** For every `Intent a`, there exists a
    handwritten JSON script with identical wallet behavior.
 2. **Deterministic compilation.** Same `Intent` → same JSON.
 3. **No runtime effects.** Compilation is pure.
-4. **WASM-neutral.** Identical under native GHC and
-   `wasm32-wasi-ghc`.
+4. **Native-only.** The eDSL and its compiler target native GHC
+   against `cardano-api` / `cardano-node-clients`. No WASM target.
 
 ## Status
 
 Design-phase. No code yet. The shape described above is the target
 surface; implementation follows once the
-[constitution](https://github.com/lambdasistemi/haskell-gamechanger/blob/main/.specify/memory/constitution.md) and this page
-stabilize.
+[constitution](https://github.com/lambdasistemi/haskell-gamechanger/blob/main/.specify/memory/constitution.md)
+and this page stabilize.

--- a/docs/scope.md
+++ b/docs/scope.md
@@ -1,0 +1,109 @@
+# Scope
+
+This page records what `haskell-gamechanger` is and is not, and why.
+The short form is a sentence:
+
+> A backend Haskell library for integrating with the GameChanger
+> wallet protocol. Not a browser library, not a WASM artifact, not
+> an alternative to CIP-30.
+
+## What this library serves
+
+Two of the three integration topologies described in
+[Integration](./integration.md):
+
+- **§6.2 — Client + backend callback.** A Haskell backend mints a
+  session token, compiles a typed `Intent` to a GameChanger script,
+  encodes a resolver URL, redirects the user's browser to it, and
+  receives the signed result on its own callback endpoint.
+- **§6.3 — Backend-only issuer.** The same backend prints resolver
+  URLs (or renders QR codes) for humans, out-of-band. The human
+  signs on whatever device holds their wallet. The result comes
+  back via `post`.
+
+Both topologies share the same Haskell value proposition: the
+library sits next to the code that already talks to
+`cardano-node`, and drops in a way to get user signatures without
+the backend ever touching keys.
+
+## What this library does not serve
+
+**Topology §6.1 — client-only.** A browser page that builds the
+script, opens the wallet, and consumes the signed result entirely
+in-browser. This is explicitly out of scope.
+
+## Why topology 6.1 is out of scope
+
+Three reasons, in order of weight.
+
+### 1. The ledger does not compile to WASM
+
+Anything that parses or validates Cardano CBOR (signed
+transactions, redeemers, protocol parameters) transitively depends
+on `cardano-ledger`, `cardano-api`, `plutus-core`, or
+`secp256k1`. None of these compile to `wasm32-wasi` today without
+deep vendoring, and even then they carry a multi-megabyte footprint
+that is wrong for a browser library. This is not a solvable
+toolchain problem on a near horizon.
+
+### 2. The Haskell value concentrates on the native side
+
+The things Haskell is genuinely the right tool for in this project
+are submission via `cardano-api`, integration with existing
+Haskell services (MPFS, MOOG, `cardano-node-clients`,
+`cardano-wallet`), and typed transaction handling in the callback
+path. None of those live in the browser.
+
+The things a browser library actually needs — JSON building,
+gzip + base64url, URL opening, optional QR generation — are
+trivial in any language. A typed Haskell surface for them would be
+nice but is not load-bearing.
+
+### 3. A schema beats a shim
+
+`GameChanger.Script`'s JSON is a stable, documented format. Any
+language can produce scripts and any language can build its own
+typed surface on top. Publishing a schema is more durable than
+publishing a WASM artifact, and it does not pretend the ledger fits
+in the browser.
+
+## What an integrator does for topology 6.1
+
+Writes the browser side in whatever tool fits:
+
+- **TypeScript** — straightforward JSON building, tiny footprint.
+- **PureScript** with `purescript-run` or similar — equivalent
+  expressivity to the Haskell eDSL via final-tagless or
+  freer-monad encodings. GADTs are not load-bearing for this
+  domain.
+- **Plain HTML + `window.location` assignment** — sufficient for
+  many flows where the backend has already produced the URL.
+
+## Three alternatives considered
+
+For posterity, the three scopes weighed before settling on this
+one:
+
+### A. Backend-only (this repository)
+
+Ship only what runs natively. Publish the JSON schema. Don't
+pretend to be in the browser. Smallest scope, cleanest story,
+biggest overlap with the project's actual Haskell workloads.
+
+### B. Backend + WASM emit path only
+
+Ship a WASM build of `Script + Intent + Encoding + QR` — no
+cardano-api, no CBOR parsing in the browser. Possible, but the
+toolchain cost and multi-megabyte artifact buy only a small
+convenience over a JS/TS client reading the same JSON schema.
+
+### C. Two codebases sharing a JSON schema
+
+Haskell for 6.2 / 6.3. A separate PureScript or TypeScript library
+for 6.1. Two implementations, one schema. Right answer if the
+browser use case grows its own weight independently; unneeded
+overhead today.
+
+**Chosen: A.** Documented here so a future reader understands why
+B and C were not picked, and can re-open the decision if the
+browser case grows enough to justify (C).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ theme:
 
 nav:
   - Overview: index.md
+  - Scope: scope.md
   - Protocol: protocol.md
   - Integration: integration.md
   - Security: security.md


### PR DESCRIPTION
## Summary

Commits the repository to **scope A**: a backend-only Haskell library
for GameChanger integrations. Topology 6.1 (client-only) and any
WASM / browser deployment are out of scope. The library targets
topologies 6.2 (client + backend callback) and 6.3 (backend-only
issuer), which is where the Haskell ecosystem already lives
(cardano-api, cardano-node-clients, cardano-wallet, MPFS, MOOG).

This is a design commitment — no code changes. The downstream
implementation tickets land after this PR merges.

## Why

Three reasons, in decreasing order of weight. The long form is in
the new [Scope](./docs/scope.md) page.

1. **The ledger does not compile to WASM.** Anything touching
   Cardano CBOR transitively depends on cardano-ledger / cardano-api
   / plutus-core / secp256k1. None of those are WASM-ready today,
   and the artifact size would be wrong for a browser library.
2. **Haskell's value concentrates on the native side.** Submission,
   integration with existing services, typed CBOR handling in the
   callback path. None of those live in the browser.
3. **A schema beats a shim.** Publishing GameChanger.Script's JSON
   as the boundary is more durable than publishing a WASM artifact,
   and doesn't pretend the ledger fits in the browser.

## Contents

### Constitution (v0.2.0 → v0.3.0)

- §8 rewritten: backend-only scope, topologies 6.2 + 6.3, JSON
  schema as the published boundary. 6.1 and WASM explicitly listed
  as out of scope.
- §11 rewritten: `Control.Monad.Operational` is the sole encoding
  (GADT + `Program` monad). Final-tagless / typeclass-indexed
  encodings are not used — pattern-matching on the GADT maps
  directly to `run`-block entries. 'native-only' invariant replaces
  'WASM-neutral'.

### Docs

- **New Scope page** (`docs/scope.md`) — one-sentence summary,
  three-reason explanation, the three alternatives considered
  (A / B / C), and what a 6.1 integrator does instead.
- **Intent eDSL page rewritten** — drops all WASM/browser framing,
  describes the native backend deployment picture, shows the
  operational-monad GADT surface and justifies the choice over
  typeclass-indexed encodings.
- **index.md** — Scope page surfaced as the first recommended read.

### Ontology

- `gc:IntentProgram` description updated: built on
  `Control.Monad.Operational`, native backend only.

## Review focus

- Does the [Scope](./docs/scope.md) page make the decision legible?
- Is the constitution internally consistent after the rewrite? (no
  lingering WASM references outside the explicit out-of-scope
  bullet in §8, no final-tagless references)
- Is the operational-monad shape in §11 and in `docs/intent-dsl.md`
  consistent?

## Next steps (post-merge)

Ten implementation tickets, one per PR, in dependency order:

1. Haskell project skeleton + `haskell.nix` + CI Build Gate
2. `GameChanger.Script` types + Aeson codec + golden tests
3. `GameChanger.Encoding` (gzip + base64url + resolver URL) with
   round-trip properties
4. `GameChanger.Intent` operational-monad surface + smart
   constructors
5. `GameChanger.Intent.Compile` deterministic compiler +
   property tests
6. `GameChanger.QR` SVG/PNG renderer
7. `GameChanger.CLI` (`hgc build`, `encode`, `qr`)
8. `GameChanger.Callback` servant combinators + session + CBOR
   strict parse
9. `hgc serve-callback` + `hgc preprod-smoke`
10. Scheduled CI job running preprod-smoke nightly