### PR TITLE
feat: haskell project skeleton + haskell.nix + CI Build Gate (#5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,44 @@ jobs:
     runs-on: nixos
     steps:
       - uses: actions/checkout@v4
-      - name: Build dev shell
-        run: nix build --quiet '.#devShells.x86_64-linux.default.inputDerivation'
+      - uses: cachix/cachix-action@v15
+        with:
+          name: paolino
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Build all derivations
+        run: >-
+          nix build --quiet
+          .#checks.x86_64-linux.library
+          .#checks.x86_64-linux.exe
+          .#checks.x86_64-linux.tests
+          .#checks.x86_64-linux.lint
+          .#devShells.x86_64-linux.default.inputDerivation
+
+  tests:
+    name: Tests
+    needs: build-gate
+    runs-on: nixos
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/cachix-action@v15
+        with:
+          name: paolino
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Run tests
+        run: nix run --quiet .#tests
+
+  lint:
+    name: Lint
+    needs: build-gate
+    runs-on: nixos
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/cachix-action@v15
+        with:
+          name: paolino
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Run lint
+        run: nix run --quiet .#lint
 
   docs:
     name: Docs (strict build + PR preview)
@@ -25,6 +61,10 @@ jobs:
     runs-on: nixos
     steps:
       - uses: actions/checkout@v4
+      - uses: cachix/cachix-action@v15
+        with:
+          name: paolino
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Build docs
         run: nix develop --quiet -c just build-docs

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ site/
 result
 result-*
 .direnv/
+dist-newstyle/
+cabal.project.local
+.ghc.environment.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,34 @@
+# CLAUDE.md — haskell-gamechanger
+
+Repository bootstrap for Claude Code sessions.
+
+## Context
+
+- **Scope**: backend-only Haskell library for the GameChanger browser
+  wallet. No browser / WASM target. See
+  [docs/scope.md](./docs/scope.md).
+- **Encoding**: the Intent eDSL uses `Control.Monad.Operational`. No
+  final-tagless / typeclass-indexed encodings. See
+  [constitution §11](./.specify/memory/constitution.md).
+
+## Workflow
+
+- Every ticket goes through speckit: `/speckit.specify` →
+  `/speckit.plan` → `/speckit.tasks` → `/speckit.implement`.
+- Load the `workflow` skill at the start of any coding session here.
+- Any change to protocol model updates **constitution + docs +
+  ontology** in one vertical commit (governance rule).
+
+## Build
+
+- `nix develop` enters the dev shell.
+- `just ci` runs the full local gate (build + test + format-check +
+  hlint).
+- CI on `nixos` self-hosted runners via the Build Gate pattern.
+
+## Links
+
+- [Constitution](./.specify/memory/constitution.md)
+- [Scope](./docs/scope.md)
+- [Intent eDSL](./docs/intent-dsl.md)
+- [Issue tracker](https://github.com/lambdasistemi/haskell-gamechanger/issues)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | @hgc@ executable entry point.
+
+Skeleton stub: prints the library version and exits. Real
+subcommands (@build@, @encode@, @qr@, @serve-callback@,
+@preprod-smoke@) land in tickets #11 and #13.
+-}
+module Main (
+    main,
+) where
+
+import qualified Data.Text.IO as T
+import GameChanger (version)
+
+main :: IO ()
+main = T.putStrLn $ "hgc " <> version

--- a/cabal.project
+++ b/cabal.project
@@ -1,7 +1,7 @@
 packages: .
 
 index-state:
-  , hackage.haskell.org 2026-04-20T00:00:00Z
-  , cardano-haskell-packages 2026-04-20T00:00:00Z
+  , hackage.haskell.org 2026-04-19T00:00:00Z
+  , cardano-haskell-packages 2026-04-19T00:00:00Z
 
 tests: True

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,7 @@
+packages: .
+
+index-state:
+  , hackage.haskell.org 2026-04-20T00:00:00Z
+  , cardano-haskell-packages 2026-04-20T00:00:00Z
+
+tests: True

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,739 @@
+{
+  "nodes": {
+    "CHaP": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1776254461,
+        "narHash": "sha256-kB2azmnVPcQ4pFBvXCc3iKlMuoLsaPRbVP0LfD5j2Zg=",
+        "owner": "intersectmbo",
+        "repo": "cardano-haskell-packages",
+        "rev": "d8156d61840f90f0721c396f0598652f7aaf402a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "intersectmbo",
+        "ref": "repo",
+        "repo": "cardano-haskell-packages",
+        "type": "github"
+      }
+    },
+    "HTTP": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
+    "cabal-34": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1645834128,
+        "narHash": "sha256-wG3d+dOt14z8+ydz4SL7pwGfe7SiimxcD/LOuPCV6xM=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "5ff598c67f53f7c4f48e31d722ba37172230c462",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-36": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1669081697,
+        "narHash": "sha256-I5or+V7LZvMxfbYgZATU4awzkicBwwok4mVoje+sGmU=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "8fd619e33d34924a94e691c5fea2c42f0fc7f144",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cardano-shell": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
+    "dev-assets-mkdocs": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "dir": "mkdocs",
+        "lastModified": 1774009337,
+        "narHash": "sha256-5h+NQA6miO3EoCgcF1LL+AgHmRlkApTVe64ke0OsKxk=",
+        "owner": "paolino",
+        "repo": "dev-assets",
+        "rev": "c000cbbef7c586356306da415a4e4b87bfcaa6e8",
+        "type": "github"
+      },
+      "original": {
+        "dir": "mkdocs",
+        "owner": "paolino",
+        "repo": "dev-assets",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1672831974,
+        "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "45f2638735f8cdc40fe302742b79f248d23eb368",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "hkm/gitlab-fix",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1763759067,
+        "narHash": "sha256-LlLt2Jo/gMNYAwOgdRQBrsRoOz7BPRkzvNaI/fzXi2Q=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "2cccadc7357c0ba201788ae99c4dfa90728ef5e0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "hackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1776645738,
+        "narHash": "sha256-4n3/dxUsTQH/5HAUD8e6oavT3iA6jUfH0F57vSQJnPU=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "a78a2a5e29b8a9e15dd7ba58bd49d8d7868bbc48",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage-for-stackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1776645728,
+        "narHash": "sha256-MbQlCWuYoVCkMa5KnTT0lltfSuA15XDBl4CIpPB+zGc=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "35a3d9acb4e66e6c7b9a0f83eaf40fe73645f450",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "for-stackage",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage-internal": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1750307553,
+        "narHash": "sha256-iiafNoeLHwlSLQTyvy8nPe2t6g5AV4PPcpMeH/2/DLs=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "f7867baa8817fab296528f4a4ec39d1c7c4da4f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "haskellNix": {
+      "inputs": {
+        "HTTP": "HTTP",
+        "cabal-34": "cabal-34",
+        "cabal-36": "cabal-36",
+        "cardano-shell": "cardano-shell",
+        "flake-compat": "flake-compat",
+        "hackage": "hackage",
+        "hackage-for-stackage": "hackage-for-stackage",
+        "hackage-internal": "hackage-internal",
+        "hls": "hls",
+        "hls-1.10": "hls-1.10",
+        "hls-2.0": "hls-2.0",
+        "hls-2.10": "hls-2.10",
+        "hls-2.11": "hls-2.11",
+        "hls-2.12": "hls-2.12",
+        "hls-2.2": "hls-2.2",
+        "hls-2.3": "hls-2.3",
+        "hls-2.4": "hls-2.4",
+        "hls-2.5": "hls-2.5",
+        "hls-2.6": "hls-2.6",
+        "hls-2.7": "hls-2.7",
+        "hls-2.8": "hls-2.8",
+        "hls-2.9": "hls-2.9",
+        "hpc-coveralls": "hpc-coveralls",
+        "iserv-proxy": "iserv-proxy",
+        "nixpkgs": [
+          "haskellNix",
+          "nixpkgs-unstable"
+        ],
+        "nixpkgs-2305": "nixpkgs-2305",
+        "nixpkgs-2311": "nixpkgs-2311",
+        "nixpkgs-2405": "nixpkgs-2405",
+        "nixpkgs-2411": "nixpkgs-2411",
+        "nixpkgs-2505": "nixpkgs-2505",
+        "nixpkgs-2511": "nixpkgs-2511",
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "old-ghc-nix": "old-ghc-nix",
+        "stackage": "stackage"
+      },
+      "locked": {
+        "lastModified": 1776647376,
+        "narHash": "sha256-gYBQBtHeH99plVjWRT9znv/b3vv8ualWDZjlrV6QU/U=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "6adbcd11d13e2ea5961bb2caa2277441ac23ca98",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "hls": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1741604408,
+        "narHash": "sha256-tuq3+Ip70yu89GswZ7DSINBpwRprnWnl6xDYnS4GOsc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "682d6894c94087da5e566771f25311c47e145359",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-1.10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1680000865,
+        "narHash": "sha256-rc7iiUAcrHxwRM/s0ErEsSPxOR3u8t7DvFeWlMycWgo=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b08691db779f7a35ff322b71e72a12f6e3376fd9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "1.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.0": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1687698105,
+        "narHash": "sha256-OHXlgRzs/kuJH8q7Sxh507H+0Rb8b7VOiPAjcY9sM1k=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "783905f211ac63edf982dd1889c671653327e441",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.0.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1743069404,
+        "narHash": "sha256-q4kDFyJDDeoGqfEtrZRx4iqMVEC2MOzCToWsFY+TOzY=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "2318c61db3a01e03700bd4b05665662929b7fe8b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.11": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747306193,
+        "narHash": "sha256-/MmtpF8+FyQlwfKHqHK05BdsxC9LHV70d/FiMM7pzBM=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "46ef4523ea4949f47f6d2752476239f1c6d806fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.11.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.12": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1758709460,
+        "narHash": "sha256-xkI8MIIVEVARskfWbGAgP5sHG/lyeKnkm0LIOJ19X5w=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "7d983de4fa7ff54369f6dd31444bdb9869aec83e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.12.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1693064058,
+        "narHash": "sha256-8DGIyz5GjuCFmohY6Fa79hHA/p1iIqubfJUTGQElbNk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b30f4b6cf5822f3112c35d14a0cba51f3fe23b85",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.2.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1695910642,
+        "narHash": "sha256-tR58doOs3DncFehHwCLczJgntyG/zlsSd7DgDgMPOkI=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "458ccdb55c9ea22cd5d13ec3051aaefb295321be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.3.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1699862708,
+        "narHash": "sha256-YHXSkdz53zd0fYGIYOgLt6HrA0eaRJi9mXVqDgmvrjk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "54507ef7e85fa8e9d0eb9a669832a3287ffccd57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.4.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1701080174,
+        "narHash": "sha256-fyiR9TaHGJIIR0UmcCb73Xv9TJq3ht2ioxQ2mT7kVdc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "27f8c3d3892e38edaef5bea3870161815c4d014c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.5.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1705325287,
+        "narHash": "sha256-+P87oLdlPyMw8Mgoul7HMWdEvWP/fNlo8jyNtwME8E8=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "6e0b342fa0327e628610f2711f8c3e4eaaa08b1e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.6.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1708965829,
+        "narHash": "sha256-LfJ+TBcBFq/XKoiNI7pc4VoHg4WmuzsFxYJ3Fu+Jf+M=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "50322b0a4aefb27adc5ec42f5055aaa8f8e38001",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.7.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.8": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1715153580,
+        "narHash": "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "dd1be1beb16700de59e0d6801957290bcf956a0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.8.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.9": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1719993701,
+        "narHash": "sha256-wy348++MiMm/xwtI9M3vVpqj2qfGgnDcZIGXw8sF1sA=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "90319a7e62ab93ab65a95f8f2bcf537e34dae76a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.9.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hpc-coveralls": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
+    "iserv-proxy": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775620557,
+        "narHash": "sha256-10x8/G0x3eR/++XRHPx4MBuqlnc6+N+ajIxXyLkG+nU=",
+        "owner": "stable-haskell",
+        "repo": "iserv-proxy",
+        "rev": "3f7b2815307c20a0dfd816bdf4a39ab86af3e0d4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "stable-haskell",
+        "ref": "iserv-syms",
+        "repo": "iserv-proxy",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1763678758,
+        "narHash": "sha256-+hBiJ+kG5IoffUOdlANKFflTT5nO3FrrR2CA3178Y5s=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "117cc7f94e8072499b0a7aa4c52084fa4e11cc9b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2305": {
+      "locked": {
+        "lastModified": 1705033721,
+        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2311": {
+      "locked": {
+        "lastModified": 1719957072,
+        "narHash": "sha256-gvFhEf5nszouwLAkT9nWsDzocUTqLWHuL++dvNjMp9I=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7144d6241f02d171d25fba3edeaf15e0f2592105",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2405": {
+      "locked": {
+        "lastModified": 1735564410,
+        "narHash": "sha256-HB/FA0+1gpSs8+/boEavrGJH+Eq08/R2wWNph1sM1Dg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1e7a8f391f1a490460760065fa0630b5520f9cf8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2411": {
+      "locked": {
+        "lastModified": 1751290243,
+        "narHash": "sha256-kNf+obkpJZWar7HZymXZbW+Rlk3HTEIMlpc6FCNz0Ds=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5ab036a8d97cb9476fbe81b09076e6e91d15e1b6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2505": {
+      "locked": {
+        "lastModified": 1764560356,
+        "narHash": "sha256-M5aFEFPppI4UhdOxwdmceJ9bDJC4T6C6CzCK1E2FZyo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6c8f0cca84510cc79e09ea99a299c9bc17d03cb6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2511": {
+      "locked": {
+        "lastModified": 1764572236,
+        "narHash": "sha256-hLp6T/vKdrBQolpbN3EhJOKTXZYxJZPzpnoZz+fEGlE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b0924ea1889b366de6bb0018a9db70b2c43a15f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1761765539,
+        "narHash": "sha256-b0yj6kfvO8ApcSE+QmA6mUfu8IYG6/uU28OFn4PaC8M=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "719359f4562934ae99f5443f20aa06c2ffff91fc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1764587062,
+        "narHash": "sha256-hdFa0TAVQAQLDF31cEW3enWmBP+b592OvHs6WVe3D8k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c1cb7d097cb250f6e1904aacd5f2ba5ffd8a49ce",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "old-ghc-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "CHaP": "CHaP",
+        "dev-assets-mkdocs": "dev-assets-mkdocs",
+        "flake-utils": "flake-utils",
+        "haskellNix": "haskellNix",
+        "nixpkgs": [
+          "haskellNix",
+          "nixpkgs-unstable"
+        ]
+      }
+    },
+    "stackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1776644707,
+        "narHash": "sha256-fRXXEO5W1VDp0tagVnq/0/FW7fnLqveO9CMz3P3VauQ=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "2cf990f99ccb78274ec7607c0158957d0ead559c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,24 +1,62 @@
 {
   description = "haskell-gamechanger — Haskell client for the GameChanger Cardano wallet";
 
+  nixConfig = {
+    extra-substituters = [ "https://cache.iog.io" ];
+    extra-trusted-public-keys = [
+      "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
+    ];
+  };
+
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    haskellNix.url = "github:input-output-hk/haskell.nix";
+    nixpkgs.follows = "haskellNix/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    CHaP = {
+      url = "github:intersectmbo/cardano-haskell-packages?ref=repo";
+      flake = false;
+    };
     dev-assets-mkdocs.url = "github:paolino/dev-assets?dir=mkdocs";
   };
 
-  outputs = { self, nixpkgs, flake-utils, dev-assets-mkdocs }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    { self
+    , nixpkgs
+    , flake-utils
+    , haskellNix
+    , CHaP
+    , dev-assets-mkdocs
+    , ...
+    }:
+    flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
       let
-        pkgs = import nixpkgs { inherit system; };
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ haskellNix.overlay ];
+          inherit (haskellNix) config;
+        };
+
+        project = import ./nix/project.nix {
+          inherit pkgs CHaP dev-assets-mkdocs system;
+        };
+
+        checks = import ./nix/checks.nix {
+          inherit pkgs project;
+        };
+
+        apps = import ./nix/apps.nix {
+          inherit pkgs checks;
+          hgc = project.hsPkgs.haskell-gamechanger.components.exes.hgc;
+        };
       in
       {
-        devShells.default = pkgs.mkShell {
-          inputsFrom = [ dev-assets-mkdocs.devShells.${system}.default ];
-          packages = [
-            pkgs.just
-            pkgs.nodejs
-          ];
+        packages = {
+          default = project.hsPkgs.haskell-gamechanger.components.exes.hgc;
+          hgc = project.hsPkgs.haskell-gamechanger.components.exes.hgc;
         };
+
+        devShells.default = project.shell;
+
+        inherit checks apps;
       });
 }

--- a/haskell-gamechanger.cabal
+++ b/haskell-gamechanger.cabal
@@ -1,0 +1,65 @@
+cabal-version: 3.0
+name:          haskell-gamechanger
+version:       0.1.0.0
+synopsis:      Haskell client for the GameChanger Cardano wallet
+description:
+  Backend-only Haskell library for driving the GameChanger browser
+  wallet via its JSON script protocol. See the
+  <https://lambdasistemi.github.io/haskell-gamechanger/ documentation>
+  for scope, protocol notes, and integration topologies.
+
+license:       Apache-2.0
+license-file:  LICENSE
+author:        Paolo Veronelli
+maintainer:    paolo.veronelli@gmail.com
+copyright:     2026 Paolo Veronelli
+category:      Cardano
+build-type:    Simple
+homepage:      https://lambdasistemi.github.io/haskell-gamechanger/
+bug-reports:
+  https://github.com/lambdasistemi/haskell-gamechanger/issues
+
+source-repository head
+  type:     git
+  location: https://github.com/lambdasistemi/haskell-gamechanger
+
+common warnings
+  ghc-options:
+    -Wall -Wcompat -Widentities -Wincomplete-record-updates
+    -Wincomplete-uni-patterns -Wmissing-export-lists
+    -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
+
+library
+  import:           warnings
+  hs-source-dirs:   src
+  exposed-modules:  GameChanger
+  build-depends:
+    , base  >=4.19 && <5
+    , text  >=2.0  && <2.2
+
+  default-language: Haskell2010
+
+executable hgc
+  import:           warnings
+  main-is:          Main.hs
+  hs-source-dirs:   app
+  build-depends:
+    , base                 >=4.19 && <5
+    , haskell-gamechanger
+    , text                 >=2.0  && <2.2
+
+  default-language: Haskell2010
+
+test-suite test
+  import:           warnings
+  type:             exitcode-stdio-1.0
+  main-is:          Spec.hs
+  hs-source-dirs:   test
+  build-depends:
+    , base                 >=4.19 && <5
+    , haskell-gamechanger
+    , tasty                >=1.5  && <1.6
+    , tasty-hunit          >=0.10 && <0.11
+    , text                 >=2.0  && <2.2
+
+  default-language: Haskell2010

--- a/haskell-gamechanger.cabal
+++ b/haskell-gamechanger.cabal
@@ -16,8 +16,7 @@ copyright:     2026 Paolo Veronelli
 category:      Cardano
 build-type:    Simple
 homepage:      https://lambdasistemi.github.io/haskell-gamechanger/
-bug-reports:
-  https://github.com/lambdasistemi/haskell-gamechanger/issues
+bug-reports:   https://github.com/lambdasistemi/haskell-gamechanger/issues
 
 source-repository head
   type:     git

--- a/justfile
+++ b/justfile
@@ -1,6 +1,32 @@
 default:
     @just --list
 
+# Haskell
+
+build:
+    cabal build all -O0
+
+test:
+    nix run .#tests
+
+format:
+    fourmolu -i $(find src app test -name '*.hs')
+    cabal-fmt -i haskell-gamechanger.cabal
+
+format-check:
+    fourmolu -m check $(find src app test -name '*.hs')
+    cabal-fmt -c haskell-gamechanger.cabal
+
+hlint:
+    hlint src app test
+
+lint:
+    nix run .#lint
+
+ci: build test format-check hlint
+
+# Docs
+
 build-docs:
     mkdocs build --strict
 
@@ -9,5 +35,3 @@ serve-docs:
 
 deploy-docs:
     mkdocs gh-deploy --force
-
-ci: build-docs

--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -1,0 +1,14 @@
+{ pkgs, checks, hgc, ... }:
+
+let
+  runnable = {
+    inherit hgc;
+    inherit (checks) tests lint;
+  };
+in
+builtins.mapAttrs
+  (_: drv: {
+    type = "app";
+    program = pkgs.lib.getExe drv;
+  })
+  runnable

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -1,0 +1,23 @@
+{ pkgs, project, ... }:
+
+let
+  hsPkgs = project.hsPkgs.haskell-gamechanger;
+  shell = project.shell;
+in
+{
+  library = hsPkgs.components.library;
+  exe = hsPkgs.components.exes.hgc;
+  tests = hsPkgs.components.tests.test;
+
+  lint = pkgs.writeShellApplication {
+    name = "lint";
+    runtimeInputs = shell.nativeBuildInputs ++ shell.buildInputs;
+    excludeShellChecks = [ "SC2046" "SC2086" ];
+    text = ''
+      cd "${./..}"
+      fourmolu -m check $(find src app test -name '*.hs')
+      cabal-fmt -c haskell-gamechanger.cabal
+      hlint src app test
+    '';
+  };
+}

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -15,7 +15,7 @@ let
     };
     withHoogle = false;
     buildInputs =
-      [ pkgs.just ]
+      [ pkgs.just pkgs.nodejs ]
       ++ dev-assets-mkdocs.devShells.${system}.default.buildInputs or [ ];
     inputsFrom = [ dev-assets-mkdocs.devShells.${system}.default ];
   };

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -1,0 +1,34 @@
+{ pkgs, CHaP, dev-assets-mkdocs, system, ... }:
+
+let
+  indexState = "2026-04-19T00:00:00Z";
+
+  shell = { pkgs, ... }: {
+    tools = {
+      cabal = { index-state = indexState; };
+      cabal-fmt = {
+        index-state = indexState;
+        compiler-nix-name = "ghc984";
+      };
+      fourmolu = { index-state = indexState; };
+      hlint = { index-state = indexState; };
+    };
+    withHoogle = false;
+    buildInputs =
+      [ pkgs.just ]
+      ++ dev-assets-mkdocs.devShells.${system}.default.buildInputs or [ ];
+    inputsFrom = [ dev-assets-mkdocs.devShells.${system}.default ];
+  };
+
+  mkProject = { lib, pkgs, ... }: {
+    name = "haskell-gamechanger";
+    src = ./..;
+    compiler-nix-name = "ghc9123";
+    inputMap."https://chap.intersectmbo.org/" = CHaP;
+    shell = shell { inherit pkgs; };
+    modules = [ ];
+  };
+
+  project = pkgs.haskell-nix.cabalProject' mkProject;
+in
+project

--- a/specs/001-haskell-project-skeleton/plan.md
+++ b/specs/001-haskell-project-skeleton/plan.md
@@ -12,7 +12,7 @@ No domain code lands. The library exposes one placeholder module `GameChanger`. 
 
 ## Technical Context
 
-**Language/Version**: GHC 9.6.6 (pinned via haskell.nix). Rationale: recent enough to match what `cardano-api` / `cardano-node-clients` ship in lambdasistemi repos today; conservative enough that `haskell.nix` has warm caches.
+**Language/Version**: GHC 9.12.3 (pinned via haskell.nix). Rationale: latest stable; aligns with the `haskell-wasm` skill's `all_9_12` toolchain should WASM ever re-enter scope as a non-goal target for a sibling project; matches the GHC the org is moving active work onto.
 **Primary Dependencies**: `base`, `text`, `bytestring`. The skeleton library has no Cardano deps yet — those arrive per-module in later tickets.
 **Build backend**: `haskell.nix` via its flake, inputs sourced to match `cardano-utxo-csmt` / `haskell-csmt` so Cachix hits cross-repo.
 **Index**: `CHaP` (Cardano Haskell Packages) is wired in from day one — later tickets will need it and it costs nothing to include empty.
@@ -27,7 +27,7 @@ No domain code lands. The library exposes one placeholder module `GameChanger`. 
 
 | Tool       | Version            | Source                               |
 |------------|--------------------|--------------------------------------|
-| GHC        | 9.6.6              | `haskell.nix` compiler selection     |
+| GHC        | 9.12.3             | `haskell.nix` compiler selection     |
 | fourmolu   | 0.15.0.0           | `haskell.nix` tool layer             |
 | hlint      | 3.8                | `haskell.nix` tool layer             |
 | cabal-fmt  | 0.1.12             | `haskell.nix` tool layer             |

--- a/specs/001-haskell-project-skeleton/plan.md
+++ b/specs/001-haskell-project-skeleton/plan.md
@@ -1,0 +1,186 @@
+# Implementation Plan: Haskell project skeleton + haskell.nix + CI Build Gate
+
+**Branch**: `feat/issue-5-skeleton` | **Date**: 2026-04-20 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification at `specs/001-haskell-project-skeleton/spec.md`
+**Ticket**: [#5](https://github.com/lambdasistemi/haskell-gamechanger/issues/5)
+
+## Summary
+
+Stand up the minimum repo state from which tickets #6–#14 can ship. That means: a buildable one-package cabal project with a library, a `hgc` executable stub, and a test suite; a `haskell.nix`-backed flake that exposes `packages / devShells / apps / checks` in the shapes the `new-repository` and `nix` skills assume; a `justfile` with the gate recipes the `workflow` skill expects; and a CI workflow that uses the Build Gate pattern so self-hosted `nixos` runners do not deadlock on the shared Nix store.
+
+No domain code lands. The library exposes one placeholder module `GameChanger`. The test suite is a single trivial check. The point is that ticket #6 can land its first `GameChanger.Script` module by editing only cabal + `src/` — no flake, justfile, or CI edits required (spec SC-004).
+
+## Technical Context
+
+**Language/Version**: GHC 9.6.6 (pinned via haskell.nix). Rationale: recent enough to match what `cardano-api` / `cardano-node-clients` ship in lambdasistemi repos today; conservative enough that `haskell.nix` has warm caches.
+**Primary Dependencies**: `base`, `text`, `bytestring`. The skeleton library has no Cardano deps yet — those arrive per-module in later tickets.
+**Build backend**: `haskell.nix` via its flake, inputs sourced to match `cardano-utxo-csmt` / `haskell-csmt` so Cachix hits cross-repo.
+**Index**: `CHaP` (Cardano Haskell Packages) is wired in from day one — later tickets will need it and it costs nothing to include empty.
+**Testing**: `tasty` + `tasty-hunit` for the trivial placeholder. `tasty-quickcheck` not pulled in yet; arrives when #6 needs it.
+**Target Platform**: `x86_64-linux` only at first. No mac, no WASM (constitution §8).
+**Project Type**: Haskell library + CLI. Single-package cabal project.
+**Performance Goals**: N/A — skeleton has no runtime work.
+**Constraints**: `just ci` must complete in <5 min cold, <60 s warm (SC-001). CI wall-clock <4 min warm (SC-002).
+**Scale/Scope**: ~10 files, ~50 LOC Haskell, plus Nix / CI / justfile scaffolding.
+
+### Dependencies pinned
+
+| Tool       | Version            | Source                               |
+|------------|--------------------|--------------------------------------|
+| GHC        | 9.6.6              | `haskell.nix` compiler selection     |
+| fourmolu   | 0.15.0.0           | `haskell.nix` tool layer             |
+| hlint      | 3.8                | `haskell.nix` tool layer             |
+| cabal-fmt  | 0.1.12             | `haskell.nix` tool layer             |
+| just       | from `nixpkgs`     | dev shell                            |
+| cabal-install | 3.10 (bundled via haskell.nix) | dev shell             |
+
+Versions live in `flake.nix` so local and CI match byte-for-byte (spec FR-006).
+
+## Constitution Check
+
+Checking the amended constitution (v0.3.0, §§ relevant to this ticket):
+
+- **§8 Scope** — native-only, no WASM target. ✅ This plan targets `x86_64-linux` via `haskell.nix`; no WASM. The flake's `packages.default` is a native executable. No `arch(wasm32)` conditionals introduced.
+- **§11 Intent eDSL** — operational monad only. N/A — no domain code lands here. The skeleton does not prejudice the encoding; it only makes the cabal library a home for `GameChanger.Intent` later.
+- **§14 CI gates** — Build Gate pattern mandatory. ✅ Explicit in this plan; see §"CI wiring" below.
+- **Governance rule — vertical commits, docs travel with code** — ✅ This ticket is itself vertical (types→build→CI→docs-of-the-skeleton via Haddock on `GameChanger`). No split between "add cabal" and "add CI" — both land in the same PR.
+
+No complexity tracking entries: nothing here deviates from a single-package project.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-haskell-project-skeleton/
+├── spec.md              # feature spec (done)
+├── plan.md              # this file
+├── research.md          # §Research below as a split-out doc (Phase 0 artefact)
+├── quickstart.md        # developer onboarding walkthrough (Phase 1 artefact)
+└── tasks.md             # produced by /speckit.tasks
+```
+
+No `data-model.md` (skeleton has no domain entities). No `contracts/` directory (skeleton exposes no API). Both are intentionally omitted per the speckit template's "delete unused options" guidance.
+
+### Source code (repository root)
+
+```text
+haskell-gamechanger/
+├── .github/workflows/
+│   ├── ci.yml                # real Build Gate + fan-out (replaces the stub)
+│   └── deploy-docs.yml       # unchanged
+├── .specify/
+│   └── memory/constitution.md
+├── app/
+│   └── Main.hs               # trivial `hgc` stub — prints version, exits 0
+├── src/
+│   └── GameChanger.hs        # placeholder module, one export: `version :: Text`
+├── test/
+│   └── Spec.hs               # tasty entry point; one passing unit test
+├── data/rdf/                 # existing — ontology Turtle
+├── docs/                     # existing — MkDocs site
+├── nix/
+│   ├── project.nix           # haskell.nix cabalProject' definition
+│   ├── checks.nix            # library / exe / tests / lint check derivations
+│   └── apps.nix              # runnable wrappers over checks
+├── flake.nix                 # thin wiring — imports from nix/
+├── flake.lock
+├── cabal.project             # index-state pin, CHaP source-repository-package
+├── cabal.project.local       # -O0 -Wwarn (dev only)
+├── haskell-gamechanger.cabal # library + exe + test-suite stanzas
+├── justfile                  # build / test / format / format-check / hlint / lint / ci
+├── CLAUDE.md                 # pointer to workflow skill + constitution
+└── README.md                 # unchanged
+```
+
+**Structure Decision**: single-package cabal project, one flake, nix code split into `project.nix` / `checks.nix` / `apps.nix` per the `nix` skill's recommended layout. This gives ticket #6 a single cabal file and a single `src/` tree to extend — the skeleton's SC-004 contract.
+
+## Design decisions (Phase 0)
+
+### D1. `haskell.nix` over plain `nixpkgs.haskellPackages`
+
+`haskell.nix` is the pattern in every active lambdasistemi Haskell repo (`cardano-utxo-csmt`, `haskell-csmt`, `mpfs`, `moog`). Using it here gives us:
+- CHaP wiring from day one, so #6 / #12 / #13 can pull `cardano-api` / `cardano-node-clients` without a Nix migration;
+- shared Cachix cache hits with those repos;
+- `shell.additional` escape hatch for public sublibraries (relevant once `cardano-api` enters, not today).
+
+`nixpkgs.haskellPackages` would work for the empty skeleton but would force a migration the moment ticket #6 pulls a Cardano dep. Migrating later is a bigger change than starting there.
+
+### D2. One cabal package, not a multi-package project
+
+Every Scope A module (`GameChanger.Script`, `.Encoding`, `.Intent`, `.QR`, `.Callback`) is a different module in the same library. Splitting them into separate cabal packages would multiply boilerplate without payoff — they compile together, ship together, and have overlapping deps.
+
+The `hgc` executable and the test suite stay in the same cabal file, two separate stanzas.
+
+### D3. One CI workflow file
+
+`ci.yml` carries: `build-gate` → fan-out (`tests`, `lint`). No separate `format.yml` / `lint.yml` / `typos.yml` workflows — they fragment the Build Gate contract. Everything feeds through the `lint` check derivation (fourmolu check + cabal-fmt check + hlint), invoked by the `lint` app.
+
+### D4. `CLAUDE.md` at the repo root
+
+The workflow skill's opening rule is "always load workflow skill at start of coding session when relevant." Adding a `CLAUDE.md` that names the skill + links the constitution means future sessions bootstrap correctly without this being rediscovered each time. One file, ~20 lines.
+
+### D5. No `.github/dependabot.yml`, no release-please
+
+Release automation is out of scope (spec). No Hackage publication path yet. Dependabot against a haskell.nix repo is noisy and low-value. Both are deliberately absent — future tickets can add them.
+
+### D6. `tasty` as the test framework
+
+Every downstream ticket will want property tests (tasty-quickcheck) and golden tests (tasty-golden). Starting on tasty avoids rewriting the test stanza when #6 lands. The skeleton pulls only `tasty` + `tasty-hunit`; others arrive on demand.
+
+## Phase 1 deliverables
+
+### Quickstart (`quickstart.md`)
+
+A one-page walkthrough for a contributor picking up a downstream ticket: clone, `nix develop`, run `just ci`, add a module to the cabal file, rebuild. Lives alongside the spec under `specs/001-haskell-project-skeleton/quickstart.md`. Its existence is the user-testable evidence that Story 1 works end-to-end (spec User Story 1).
+
+### CI wiring (`.github/workflows/ci.yml`)
+
+Three jobs:
+
+1. **build-gate** (`runs-on: nixos`, needs: nothing)
+   - `nix build .#checks.x86_64-linux.library`
+   - `nix build .#checks.x86_64-linux.exe`
+   - `nix build .#checks.x86_64-linux.tests`
+   - `nix build .#checks.x86_64-linux.lint`
+   - `nix build .#devShells.x86_64-linux.default.inputDerivation`
+2. **tests** (`needs: build-gate`) — `nix run .#tests`
+3. **lint** (`needs: build-gate`) — `nix run .#lint`
+
+Cachix configured with `paolino` cache and `CACHIX_AUTH_TOKEN` secret. Concurrency group `${{ github.workflow }}-${{ github.ref }}`, cancel in progress. No `continue-on-error`, no `if: always()`. `deploy-docs.yml` untouched.
+
+### Justfile
+
+```
+default: build
+build:       cabal build all
+test:        nix run .#tests
+format:      fourmolu -i src app test; cabal-fmt -i haskell-gamechanger.cabal
+format-check: fourmolu -m check src app test; cabal-fmt -c haskell-gamechanger.cabal
+hlint:       hlint src app test
+lint:        nix run .#lint
+ci:          just build && just test && just format-check && just hlint
+```
+
+`ci` runs the same steps CI runs, in the same order, so `just ci` green ⇒ CI green (barring network / runner issues).
+
+### Lint check derivation
+
+`nix/checks.nix` exposes `lint` as a `pkgs.writeShellApplication` that runs fourmolu (check), cabal-fmt (check), hlint — the composite of FR-014. CI consumes this via `.#checks.lint` (build gate) and `.#apps.lint` (stdout-visible in CI log).
+
+## Re-check of Constitution after Phase 1
+
+All checks from §"Constitution Check" still pass; nothing in the Phase 1 deliverables introduces a WASM surface, a typeclass-indexed DSL, or a non-native build target. No new complexity entries.
+
+## Rollout
+
+1. Land spec on `feat/issue-5-skeleton` (done).
+2. Land plan + quickstart on same branch (this step).
+3. `/speckit.tasks` to produce `tasks.md`.
+4. `/speckit.implement` per task.
+5. Open PR, label `chore`, assign paolino, CI green, merge via rebase.
+6. Close ticket #5. The issue-dependency graph unblocks #6 and #8 simultaneously.
+
+## Complexity Tracking
+
+No violations. Table omitted.

--- a/specs/001-haskell-project-skeleton/quickstart.md
+++ b/specs/001-haskell-project-skeleton/quickstart.md
@@ -1,0 +1,101 @@
+# Quickstart — contributing to haskell-gamechanger
+
+Target audience: a contributor starting a downstream Scope A ticket (#6–#14) or a reviewer verifying the skeleton works end-to-end.
+
+## One-time setup
+
+```bash
+git clone git@github.com:lambdasistemi/haskell-gamechanger.git
+cd haskell-gamechanger
+direnv allow          # optional — auto-enters nix develop
+```
+
+No local Haskell install needed. Everything runs through `nix develop`.
+
+## Daily loop
+
+Enter the dev shell:
+
+```bash
+nix develop --quiet
+```
+
+Build, test, and run the gate:
+
+```bash
+just build         # cabal build all
+just test          # run the tasty suite
+just ci            # build + test + format-check + hlint — same as CI
+```
+
+Format code in place:
+
+```bash
+just format        # fourmolu -i + cabal-fmt -i
+```
+
+Run `hgc`:
+
+```bash
+nix run .#hgc -- --version
+# or
+cabal run hgc -- --version
+```
+
+## Adding a new module
+
+Let's walk through what ticket #6 will do — adding `GameChanger.Script`:
+
+1. Create `src/GameChanger/Script.hs` with your module body.
+2. Add `GameChanger.Script` to the `exposed-modules:` list in `haskell-gamechanger.cabal`.
+3. Run `just build` to confirm it compiles.
+4. Add tests under `test/` and extend `test/Spec.hs` if you want a new test group.
+5. Run `just ci` to confirm the full gate passes.
+
+No flake, justfile, or CI edits are required to add a module. That is the skeleton's contract (spec SC-004).
+
+## Adding a dependency
+
+1. Add the package to the `build-depends:` list of the cabal stanza that needs it (library, exe, or test).
+2. If the package is on Hackage, nothing else is needed — the `index-state` in `cabal.project` pins the Hackage view.
+3. If the package is on CHaP (Cardano Haskell Packages) — e.g. `cardano-api` — add it under `source-repository-package` if needed; otherwise it is already resolvable via the CHaP input in `flake.nix`.
+4. Run `just build`. If `haskell.nix` complains about a missing plan, run `nix flake update` to refresh the inputs.
+
+## CI mental model
+
+```
+build-gate ──▶ tests
+           └─▶ lint
+```
+
+`build-gate` runs first and builds every check derivation and every dev-shell input, warming the shared Nix store on the self-hosted runner. The `tests` and `lint` jobs then run `nix run .#tests` and `nix run .#lint` against a warm store, so they are typically seconds rather than minutes.
+
+If `build-gate` fails, no fan-out jobs run. Fix the build first.
+
+## Common pitfalls
+
+- **Running `just` outside `nix develop`** — the recipes assume fourmolu, hlint, cabal-fmt, and cabal are on PATH. Either enter the shell (`nix develop`) or prefix with `nix develop -c`.
+- **`nix develop -c` does not run `shellHook`** — env vars set in the hook are unavailable. Do not rely on them inside recipes.
+- **Stale cache after bumping GHC** — delete `dist-newstyle/` and re-run `just build`.
+- **Local fourmolu version ≠ CI** — do not install fourmolu globally; use the one from the dev shell. Pinned in `flake.nix`.
+
+## Verifying the skeleton from scratch
+
+This is what a reviewer runs to accept ticket #5:
+
+```bash
+git checkout feat/issue-5-skeleton
+nix flake show                                      # lists expected outputs
+nix develop -c just ci                              # full local gate
+nix build .#checks.x86_64-linux.{library,exe,tests,lint}
+nix run .#hgc -- --version
+```
+
+All five commands should complete without error.
+
+## Further reading
+
+- [Constitution](https://github.com/lambdasistemi/haskell-gamechanger/blob/main/.specify/memory/constitution.md)
+- [Scope](https://github.com/lambdasistemi/haskell-gamechanger/blob/main/docs/scope.md)
+- [Intent eDSL](https://github.com/lambdasistemi/haskell-gamechanger/blob/main/docs/intent-dsl.md)
+- Ticket backlog: [#5–#14](https://github.com/lambdasistemi/haskell-gamechanger/issues?q=is%3Aissue+is%3Aopen+label%3Afeat%2Cchore%2Cci)

--- a/specs/001-haskell-project-skeleton/spec.md
+++ b/specs/001-haskell-project-skeleton/spec.md
@@ -1,0 +1,156 @@
+# Feature Specification: Haskell project skeleton + haskell.nix + CI Build Gate
+
+**Feature Branch**: `feat/issue-5-skeleton`
+**Created**: 2026-04-20
+**Status**: Draft
+**Input**: Ticket [#5](https://github.com/lambdasistemi/haskell-gamechanger/issues/5). Stand up a minimal Haskell library + executable layout so the rest of Scope A (tickets #6–#14) can build on it. No domain code yet.
+
+## User Scenarios & Testing
+
+The "users" of this feature are the next nine Scope A tickets and the project itself — not humans running a CLI. Each user story describes a capability a later ticket, a maintainer, or CI will rely on.
+
+### User Story 1 — A later ticket can add a module and ship it (Priority: P1)
+
+A contributor working on a downstream ticket (e.g. #6 `GameChanger.Script`) clones the repo, enters `nix develop`, creates a new module under a fresh or existing namespace, and builds and tests it. They do not need to set up tooling, wire CI, or decide on versions — the skeleton already covers all of that.
+
+**Why this priority**: every subsequent Scope A ticket is blocked on this one; if the skeleton is not usable end-to-end, nothing else can start.
+
+**Independent Test**: check out the merged branch, run `nix develop -c just build` and `nix develop -c just test`, confirm both succeed with an empty library and a placeholder test.
+
+**Acceptance Scenarios**:
+
+1. **Given** a clean clone of the repo at the head of this feature, **When** a contributor runs `nix develop -c just build`, **Then** the build succeeds and produces the library + executable + test suite derivations.
+2. **Given** the same clone, **When** a contributor runs `nix develop -c just test`, **Then** the placeholder test suite runs and reports success.
+3. **Given** a contributor adds a new module to the library section of the cabal file, **When** they rebuild, **Then** the new module is picked up without further configuration.
+
+---
+
+### User Story 2 — CI exercises the Build Gate pattern (Priority: P1)
+
+On every PR and every push to main, CI runs a single `Build Gate` job that builds all flake-exposed derivations (library, executable, test suite, lint, dev-shell inputDerivation). Downstream jobs (tests, formatting, hlint) depend on `Build Gate` and reuse its Nix store via Cachix, so they run against a warmed cache.
+
+**Why this priority**: self-hosted `nixos` runners share a Nix store; without the gate, parallel jobs deadlock on evaluation locks (see `new-repository` skill). Every later ticket adds checks or jobs — they all assume the gate exists.
+
+**Independent Test**: open a throwaway PR that only bumps a README character, observe CI: Build Gate runs, downstream jobs wait for it, all succeed, total wall time is dominated by Build Gate.
+
+**Acceptance Scenarios**:
+
+1. **Given** a PR against main, **When** CI runs, **Then** exactly one `Build Gate` job is scheduled and all downstream Haskell-related jobs (tests, formatting, hlint) declare `needs: build-gate`.
+2. **Given** a green Build Gate run, **When** a downstream job starts, **Then** it does not re-evaluate the flake from cold and its `nix build` steps resolve from cache within seconds.
+3. **Given** a push to main that breaks the build, **When** CI runs, **Then** Build Gate fails and downstream jobs do not start, matching the pre-merge signal.
+
+---
+
+### User Story 3 — `just` recipes are the one way to run local checks (Priority: P1)
+
+A maintainer runs the same commands locally that CI runs, by invoking `just` recipes inside `nix develop`. The recipes cover: build, test, format, format-check, hlint, lint (all three quality gates), and a `ci` recipe that runs what CI will run. No recipe silently fixes files; `format-check` fails on violations.
+
+**Why this priority**: the `workflow` skill requires `just ci` to pass before every push. This recipe must exist from day one or the rule cannot be followed on this repo.
+
+**Independent Test**: in `nix develop`, run `just ci` on a clean checkout; observe that it runs build, tests, format-check, hlint, and lint in order, and exits non-zero if any of them fail.
+
+**Acceptance Scenarios**:
+
+1. **Given** the dev shell is entered, **When** `just --list` is run, **Then** it shows recipes: `build`, `test`, `format`, `format-check`, `hlint`, `lint`, `ci`.
+2. **Given** a working tree with a formatting violation, **When** `just format-check` runs, **Then** it exits non-zero and names the offending file.
+3. **Given** a green working tree, **When** `just ci` runs, **Then** it completes with exit code 0 and prints the name of each gate as it runs.
+
+---
+
+### User Story 4 — Flake outputs are discoverable and CI-shaped (Priority: P2)
+
+The flake exposes: `packages.<system>.default` (the executable), `devShells.<system>.default`, `apps.<system>.{hgc, tests, lint}`, and `checks.<system>.{library, exe, tests, lint}`. These names match the shapes the `new-repository` and `nix` skills assume, so the CI workflow file can be copy-adapted without surprise.
+
+**Why this priority**: gets us a consistent surface across the org's repos; not strictly blocking later Scope A tickets but noticeable friction if it is missing.
+
+**Independent Test**: run `nix flake show` against the repo; confirm every expected output is present with the expected type.
+
+**Acceptance Scenarios**:
+
+1. **Given** a clean checkout, **When** `nix flake show` is run, **Then** it lists `packages.default`, `devShells.default`, at least one `apps.*`, and at least four `checks.*` entries.
+2. **Given** a CI workflow adapted from the `new-repository` skill template, **When** the workflow references `.#checks.x86_64-linux.<name>` for each name, **Then** every reference resolves to an existing derivation.
+
+---
+
+### User Story 5 — Docs CI stays green after the skeleton lands (Priority: P2)
+
+The existing `Docs (strict build + PR preview)` workflow continues to pass with no changes. The skeleton does not break the doc site, the surge preview deploys correctly on PRs, and `mkdocs build --strict` remains part of the PR gate set.
+
+**Why this priority**: the current CI has exactly two jobs (Build Gate stub + Docs). This ticket replaces the Build Gate stub with real substance; it must not collaterally break Docs.
+
+**Independent Test**: open the PR for this ticket, confirm both CI checks remain green and the surge preview renders the existing site.
+
+**Acceptance Scenarios**:
+
+1. **Given** the PR for this ticket, **When** CI runs, **Then** the Docs check is green and a surge URL is posted as a sticky comment.
+2. **Given** the PR is merged, **When** the deploy-docs workflow runs on main, **Then** the GitHub Pages site at `lambdasistemi.github.io/haskell-gamechanger` updates without error.
+
+---
+
+### Edge Cases
+
+- **Empty library with no modules**: cabal must still be able to build it. The `GameChanger` top-level module is the single placeholder.
+- **Empty test suite**: one trivial test (e.g. `assertEqual "sanity" 1 1`) so the test derivation is real, not a no-op.
+- **Version drift between local fourmolu / hlint / cabal-fmt and CI**: pin the versions in the dev shell; CI uses the same dev shell so they cannot diverge.
+- **`nix develop -c` does not run shellHook**: any env vars set in the shell hook are unavailable inside `just` recipes called through `nix develop -c`; recipes must not depend on shellHook-only state.
+- **Parallel CI jobs on the same self-hosted runner**: Build Gate must complete before the fan-out, enforced via `needs: build-gate`. No downstream job runs `nix` commands concurrently with Build Gate.
+- **CACHIX_AUTH_TOKEN missing from a fork**: the Cachix action must be configured to treat an absent token as a warning, not a hard failure, so fork PRs still build (they just don't write to the cache).
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The repository MUST contain a `haskell-gamechanger.cabal` file with three stanzas: a library, one executable named `hgc`, and one test-suite.
+- **FR-002**: The library stanza MUST expose exactly one module, `GameChanger`, as a placeholder. The module MUST contain no domain logic.
+- **FR-003**: The test-suite MUST contain at least one trivial test that passes.
+- **FR-004**: The repository MUST contain `cabal.project` and `cabal.project.local`. `cabal.project.local` MUST set `-O0` and `-Wwarn` for fast dev builds.
+- **FR-005**: The repository MUST contain a `flake.nix` whose outputs include:
+  - `packages.<system>.default` — the `hgc` executable
+  - `devShells.<system>.default` — a shell with GHC, cabal, fourmolu, hlint, cabal-fmt, just
+  - `apps.<system>.{hgc, tests, lint}` — runnable wrappers
+  - `checks.<system>.{library, exe, tests, lint}` — sandboxed CI-shaped checks
+- **FR-006**: The dev shell MUST pin fourmolu, hlint, and cabal-fmt to specific versions so local runs match CI byte-for-byte.
+- **FR-007**: The repository MUST contain a `justfile` with recipes: `build`, `test`, `format`, `format-check`, `hlint`, `lint`, `ci`.
+- **FR-008**: `just format-check` MUST fail (exit non-zero) on any formatting violation. It MUST NOT silently rewrite files.
+- **FR-009**: `just ci` MUST run build, tests, format-check, hlint, and lint in order and exit non-zero if any gate fails.
+- **FR-010**: The CI workflow at `.github/workflows/ci.yml` MUST include a `build-gate` job that builds every check derivation and every runnable flake output used by downstream jobs.
+- **FR-011**: Every CI job that invokes `nix` MUST declare `needs: build-gate`.
+- **FR-012**: The CI workflow MUST run on `runs-on: nixos` and use `cachix/cachix-action@v15` with the `paolino` cache.
+- **FR-013**: Downstream CI jobs MUST include at minimum: build + test (runs `nix run .#tests`), formatting (runs `nix run .#lint`), hlint (part of `lint` or its own job). These MAY be combined under a single `lint` derivation per the `nix` skill.
+- **FR-014**: The `lint` check MUST invoke fourmolu in check mode, cabal-fmt in check mode, and hlint with CI's fail level on every source file under the project's CI-scoped paths.
+- **FR-015**: The existing `deploy-docs.yml` workflow MUST continue to function unchanged. No skeleton change may require editing it.
+- **FR-016**: The repository MUST contain a top-level `CLAUDE.md` pointing at the `workflow` skill and the constitution, so future sessions load context consistently.
+
+### Key Entities
+
+- **Skeleton**: the union of cabal files, module stub, flake outputs, dev shell, justfile, and CI workflow — the buildable artefact other tickets extend.
+- **Build Gate**: the CI job that evaluates and builds all flake outputs once, warming the shared Nix store for downstream jobs.
+- **Check derivation**: a sandboxed Nix-built verification artefact (`checks.library`, `checks.tests`, `checks.lint`). Produced by the flake; consumed by CI.
+- **App wrapper**: a Nix `app` output that runs a check binary with stdout visible, so CI logs are readable.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: A contributor cloning the repo and running `nix develop -c just ci` on a fresh machine completes the gate in under 5 minutes (cold first build), under 60 seconds (warm rebuild).
+- **SC-002**: Opening a PR that changes a single `.hs` file in the library triggers exactly one Build Gate run and at most three downstream jobs. Total CI wall-clock time is under 4 minutes with a warm Cachix cache.
+- **SC-003**: `nix flake show` lists all outputs named in FR-005 on the first try; no missing outputs.
+- **SC-004**: The next ticket to start (#6) requires zero edits to `flake.nix`, `justfile`, or `.github/workflows/ci.yml` to add its module — only cabal file edits and new source files.
+- **SC-005**: On a violation (formatting, hlint, or build failure), `just ci` and CI both fail with a message naming the offending file within one terminal screen of output.
+
+## Assumptions
+
+- The `paolino` Cachix cache is writable from `lambdasistemi/haskell-gamechanger` CI (the `CACHIX_AUTH_TOKEN` secret is already configured on the repo).
+- Self-hosted `nixos` runners are available and healthy; no GitHub-hosted-runner fallback is required.
+- The chosen GHC version is 9.6.x (LTS-ish), matching what the downstream tickets will need for `cardano-api` / `cardano-node-clients`. This is a default — revisit in the plan step.
+- `haskell.nix` is the build backend. Source `haskell.nix` and `CHaP` from the same inputs the rest of the lambdasistemi Haskell repos use, to maximise cache hit rate.
+- The library and executable live at the repo root under `src/` and `app/`. The test suite lives under `test/`. No multi-package Cabal project — a single cabal file keeps the scaffolding as small as possible.
+- Speckit scaffolding produced a branch `001-haskell-project-skeleton`; this has been renamed to `feat/issue-5-skeleton` to match the workflow skill's naming convention.
+
+## Out of scope
+
+- Any GameChanger domain types (Script, Encoding, Intent, QR, Callback) — those are later tickets.
+- Any network-touching integration tests — the placeholder test is purely internal.
+- A multi-package cabal project — this is one library + one exe + one test.
+- Release automation (release-please, hackage upload) — handled separately once the shape is proven.
+- Cross-compilation or WASM targets — explicitly out of scope per the constitution.

--- a/specs/001-haskell-project-skeleton/tasks.md
+++ b/specs/001-haskell-project-skeleton/tasks.md
@@ -1,0 +1,198 @@
+---
+description: "Task list for feature 001 — Haskell project skeleton + haskell.nix + CI Build Gate"
+---
+
+# Tasks: Haskell project skeleton + haskell.nix + CI Build Gate
+
+**Input**: `specs/001-haskell-project-skeleton/{spec.md, plan.md, quickstart.md}`
+**Branch**: `feat/issue-5-skeleton`
+**Ticket**: [#5](https://github.com/lambdasistemi/haskell-gamechanger/issues/5)
+
+## Format: `[ID] [P?] [Story] Description`
+
+- `[P]` — can run in parallel with other `[P]` tasks in the same phase (different files, no dependencies).
+- `[Story]` — which user story in `spec.md` the task serves.
+- `[-]` — task crosses stories (infrastructure) or is phase-scoped.
+
+## Path conventions
+
+Single-package cabal project at the repo root. Haskell under `src/`, `app/`, `test/`. Nix split under `nix/`. See `plan.md` §"Project Structure".
+
+---
+
+## Phase 1: Setup (shared infrastructure)
+
+**Purpose**: files that every user story needs before any Haskell code compiles.
+
+- [ ] T001 [-] Create `cabal.project` at repo root pinning `index-state`, wiring CHaP as a `source-repository-package`, and setting `tests: True`.
+- [ ] T002 [-] Create `cabal.project.local` with `-O0` and `-Wwarn` for dev builds (gitignored).
+- [ ] T003 [-] Create `haskell-gamechanger.cabal` with three stanzas:
+  - `library` exposing `GameChanger`, hs-source-dirs: `src`, build-depends: `base, text`
+  - `executable hgc` with `main-is: Main.hs`, hs-source-dirs: `app`
+  - `test-suite test` using `exitcode-stdio-1.0`, hs-source-dirs: `test`, build-depends: `base, tasty, tasty-hunit, haskell-gamechanger`
+- [ ] T004 [-] Add `CLAUDE.md` at the repo root pointing at the workflow skill and linking the constitution (spec FR-016).
+- [ ] T005 [-] Extend `.gitignore` for `dist-newstyle/`, `cabal.project.local`, `.ghc.environment.*`, `result`, `result-*`.
+
+**Checkpoint**: cabal file exists but is not yet buildable (no source files).
+
+---
+
+## Phase 2: Foundational (blocking prerequisites)
+
+**Purpose**: minimum Haskell source so `cabal build` has something to compile, and flake inputs so `nix build` can resolve `haskell.nix`.
+
+**⚠️ CRITICAL**: no user story work can start until Phase 2 is complete.
+
+- [ ] T006 [P] [-] Create `src/GameChanger.hs` exporting `version :: Text` with the current cabal version (read at compile time via `CPP` or hard-coded for now — keep it trivial).
+- [ ] T007 [P] [-] Create `app/Main.hs` that prints `hgc <version>` and exits 0. No `optparse-applicative` yet — a `--version` flag check on `args` is enough.
+- [ ] T008 [P] [-] Create `test/Spec.hs` with a single `tasty-hunit` test asserting `GameChanger.version` is non-empty.
+- [ ] T009 [-] Rewrite `flake.nix` as a thin wrapper: inputs (`nixpkgs`, `haskell-nix`, `flake-utils`, `CHaP`), outputs per system via `flake-utils.lib.eachSystem` for `x86_64-linux`, importing `./nix/project.nix`, `./nix/checks.nix`, `./nix/apps.nix` and exposing:
+  - `packages.default = project.hsPkgs.haskell-gamechanger.components.exes.hgc`
+  - `devShells.default = project.shell`
+  - `checks = import ./nix/checks.nix { ... }`
+  - `apps = import ./nix/apps.nix { ... }`
+- [ ] T010 [-] Create `nix/project.nix` defining a `haskell.nix` `cabalProject'` pinned to GHC 9.6.6, referencing CHaP as an extra input-map, declaring the dev shell with `fourmolu`, `hlint`, `cabal-fmt`, `just`, `cabal-install` as `tools`, and using `shell.withHoogle = false` to keep startup fast.
+- [ ] T011 [-] Create `nix/checks.nix` exposing `library`, `exe`, `tests`, and `lint` (a `pkgs.writeShellApplication` running fourmolu check + cabal-fmt check + hlint across `src app test`).
+- [ ] T012 [-] Create `nix/apps.nix` wrapping the runnable checks (`exe`, `tests`, `lint`) via `pkgs.lib.getExe` so `nix run .#hgc`, `nix run .#tests`, `nix run .#lint` all work.
+- [ ] T013 [-] Run `nix flake update` once, commit the resulting `flake.lock`.
+
+**Checkpoint**: `nix develop -c cabal build all` and `nix build .#checks.x86_64-linux.library` both succeed from a fresh clone.
+
+---
+
+## Phase 3: User Story 1 — A later ticket can add a module and ship it (P1) 🎯 MVP
+
+**Goal**: `nix develop -c just build` and `nix develop -c just test` work on a fresh clone with the empty library; adding a module to cabal picks it up without further config.
+
+**Independent test**: clone the branch, run the two commands, verify they succeed.
+
+- [ ] T014 [US1] Create `justfile` with recipes: `default` (→ `build`), `build` (`cabal build all`), `test` (`nix run .#tests`), `format` (in-place fourmolu + cabal-fmt), `format-check` (check-only fourmolu + cabal-fmt), `hlint` (hlint src app test), `lint` (`nix run .#lint`), `ci` (build + test + format-check + hlint).
+- [ ] T015 [US1] Verify `nix develop -c just build` succeeds on a clean worktree.
+- [ ] T016 [US1] Verify `nix develop -c just test` succeeds and the trivial test runs.
+- [ ] T017 [US1] Verify adding a dummy module `GameChanger.Smoke` to `src/` and to `exposed-modules:` picks it up on `just build` without any flake / justfile / CI edits (spec SC-004). Revert the dummy module before committing.
+
+**Checkpoint**: Story 1 green. Any downstream ticket can now extend the library by editing only cabal + `src/`.
+
+---
+
+## Phase 4: User Story 2 — CI exercises the Build Gate pattern (P1)
+
+**Goal**: CI runs `build-gate` first, fans out to `tests` and `lint`, all three pass on a freshly pushed PR; downstream jobs benefit from the warm store.
+
+**Independent test**: push the branch, open a draft PR, observe the workflow topology and completion time.
+
+- [ ] T018 [US2] Replace the stub `.github/workflows/ci.yml` with a workflow whose `build-gate` job runs on `nixos`, uses `cachix/cachix-action@v15` with the `paolino` cache and `CACHIX_AUTH_TOKEN` secret, and runs `nix build --quiet .#checks.x86_64-linux.{library,exe,tests,lint} .#devShells.x86_64-linux.default.inputDerivation`.
+- [ ] T019 [US2] Add a `tests` job in the same workflow, `needs: build-gate`, running `nix run .#tests --quiet`.
+- [ ] T020 [US2] Add a `lint` job in the same workflow, `needs: build-gate`, running `nix run .#lint --quiet`.
+- [ ] T021 [US2] Add `concurrency: group: ${{ github.workflow }}-${{ github.ref }}, cancel-in-progress: true` at the workflow top level.
+- [ ] T022 [US2] Push the branch, wait for CI, confirm all three jobs succeed and wall-clock is within SC-002 (<4 min warm).
+
+**Checkpoint**: Story 2 green. CI matches the `new-repository` skill template and the shared-runner invariant holds.
+
+---
+
+## Phase 5: User Story 3 — `just` recipes are the one way to run local checks (P1)
+
+**Goal**: `just ci` runs every gate CI runs, in the same order. `format-check` fails on violations rather than silently fixing.
+
+**Independent test**: `just --list` shows the expected recipes; `just ci` green on clean tree; `just format-check` red after introducing a formatting violation.
+
+- [ ] T023 [US3] Sanity-check the `justfile` from T014 matches FR-007: recipes `build`, `test`, `format`, `format-check`, `hlint`, `lint`, `ci` all present.
+- [ ] T024 [US3] Add a malformed Haskell file (extra trailing space, misindented `do` block) temporarily to `src/`; run `just format-check`; assert it fails with a non-zero exit and names the file. Revert the malformation.
+- [ ] T025 [US3] Run `just ci` on a clean tree; assert exit 0 and that each gate name is printed as it runs.
+
+**Checkpoint**: Story 3 green. `just ci` is the local analogue of the CI workflow.
+
+---
+
+## Phase 6: User Story 4 — Flake outputs are discoverable and CI-shaped (P2)
+
+**Goal**: `nix flake show` lists `packages.default`, `devShells.default`, at least one `apps.*`, and at least four `checks.*` entries.
+
+**Independent test**: run `nix flake show` and inspect.
+
+- [ ] T026 [US4] Run `nix flake show` on the branch; capture output; confirm:
+  - `packages.x86_64-linux.default` present and typed as `package`
+  - `devShells.x86_64-linux.default` present
+  - `apps.x86_64-linux.{hgc, tests, lint}` present
+  - `checks.x86_64-linux.{library, exe, tests, lint}` present
+- [ ] T027 [US4] Cross-reference the `apps` names against CI workflow `nix run .#<name>` invocations in `.github/workflows/ci.yml`; assert every CI reference resolves.
+
+**Checkpoint**: Story 4 green.
+
+---
+
+## Phase 7: User Story 5 — Docs CI stays green (P2)
+
+**Goal**: the existing `deploy-docs.yml` workflow still runs and passes on the PR; the surge preview deploys as before.
+
+**Independent test**: open the PR, check the `Docs (strict build + PR preview)` check and the surge sticky-comment URL.
+
+- [ ] T028 [US5] Confirm `.github/workflows/deploy-docs.yml` is unchanged by this branch's diff.
+- [ ] T029 [US5] After pushing, confirm the Docs check is green on the PR and that a surge preview URL appears as a sticky comment.
+- [ ] T030 [US5] Manually browse the preview URL and verify the Scope / Intent eDSL / Protocol pages render.
+
+**Checkpoint**: Story 5 green.
+
+---
+
+## Phase 8: Polish & cross-cutting concerns
+
+- [ ] T031 [P] [-] Add short Haddock headers to `GameChanger.hs`, `app/Main.hs`, `test/Spec.hs` — one sentence each describing the module's role in the skeleton.
+- [ ] T032 [P] [-] Verify `fourmolu -m check` and `hlint` are clean against the skeleton (resolve any warnings here, not in a follow-up commit).
+- [ ] T033 [-] Open the PR with title `feat: haskell project skeleton + haskell.nix + CI Build Gate (#5)`, label `chore`, assign `paolino`. Include the quickstart commands in the PR body as the reviewer's verification recipe.
+- [ ] T034 [-] Wait for CI green; merge via `mcp__merge-guard__guard-merge` with `method: rebase`; remove the worktree after merge.
+- [ ] T035 [-] Close ticket #5; confirm issue-dependency graph unblocks #6 and #8 on the planner board.
+
+---
+
+## Dependencies & execution order
+
+### Phase dependencies
+
+- **Phase 1 (Setup)** — no dependencies; can start immediately.
+- **Phase 2 (Foundational)** — depends on Phase 1. Blocks all stories.
+- **Phase 3 (US1)** — depends on Phase 2.
+- **Phase 4 (US2)** — depends on Phase 2 and Phase 3 (needs working `just` recipes for local sanity before touching CI).
+- **Phase 5 (US3)** — depends on Phase 3 (justfile exists).
+- **Phase 6 (US4)** — depends on Phase 2.
+- **Phase 7 (US5)** — depends on Phase 4 (PR must exist to observe the Docs workflow running).
+- **Phase 8 (Polish)** — depends on all stories.
+
+### Task-level critical path
+
+```
+T001..T005 → T006..T008 (parallel) → T009..T012 → T013
+                                       ↓
+                                     T014 → T015,T016 → T017
+                                       ↓
+                                     T018..T022
+                                       ↓
+                                     T023..T025, T026..T027, T028..T030
+                                       ↓
+                                     T031,T032 (parallel) → T033 → T034 → T035
+```
+
+### Parallel opportunities
+
+- T006, T007, T008 operate on different files; run in parallel.
+- T031, T032 operate on different concerns; run in parallel.
+- Stories 3, 4, 6 are orthogonal once Phase 2 + T014 are done; a second contributor could pick up US4 while US2 is in flight.
+
+---
+
+## Implementation strategy
+
+MVP-first: complete Phases 1–3, stop and validate User Story 1 (an empty library that builds locally end-to-end). Only then layer on CI (Phase 4), justfile polish (Phase 5), flake discoverability (Phase 6), docs verification (Phase 7). Polish (Phase 8) is the last thing before opening the PR.
+
+Each phase ends in a green commit. No phase leaves behind a broken build, per the `workflow` skill bisect-safety rule.
+
+---
+
+## Notes
+
+- Every commit must compile and `just ci` clean — bisect-safe per the workflow skill.
+- Use `stg` if the commit history needs reshaping before the PR.
+- Push the branch after Phase 3 so the spec + plan + quickstart + first working skeleton are all browsable; do not batch.
+- Do not add release-please, dependabot, or typos workflows in this ticket — explicitly out of scope (plan D5).
+- Do not pull `cardano-api` / `cardano-node-clients` into cabal deps here — they arrive with the tickets that need them.

--- a/specs/001-haskell-project-skeleton/tasks.md
+++ b/specs/001-haskell-project-skeleton/tasks.md
@@ -51,7 +51,7 @@ Single-package cabal project at the repo root. Haskell under `src/`, `app/`, `te
   - `devShells.default = project.shell`
   - `checks = import ./nix/checks.nix { ... }`
   - `apps = import ./nix/apps.nix { ... }`
-- [ ] T010 [-] Create `nix/project.nix` defining a `haskell.nix` `cabalProject'` pinned to GHC 9.6.6, referencing CHaP as an extra input-map, declaring the dev shell with `fourmolu`, `hlint`, `cabal-fmt`, `just`, `cabal-install` as `tools`, and using `shell.withHoogle = false` to keep startup fast.
+- [ ] T010 [-] Create `nix/project.nix` defining a `haskell.nix` `cabalProject'` pinned to GHC 9.12.3 (`compiler-nix-name = "ghc9123"`), referencing CHaP as an extra input-map, declaring the dev shell with `fourmolu`, `hlint`, `cabal-fmt`, `just`, `cabal-install` as `tools`, and using `shell.withHoogle = false` to keep startup fast.
 - [ ] T011 [-] Create `nix/checks.nix` exposing `library`, `exe`, `tests`, and `lint` (a `pkgs.writeShellApplication` running fourmolu check + cabal-fmt check + hlint across `src app test`).
 - [ ] T012 [-] Create `nix/apps.nix` wrapping the runnable checks (`exe`, `tests`, `lint`) via `pkgs.lib.getExe` so `nix run .#hgc`, `nix run .#tests`, `nix run .#lint` all work.
 - [ ] T013 [-] Run `nix flake update` once, commit the resulting `flake.lock`.

--- a/src/GameChanger.hs
+++ b/src/GameChanger.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Placeholder top-level module for the haskell-gamechanger library.
+
+The library is empty by design at ticket #5 — the skeleton provides
+a buildable home for the Scope A modules that follow (@GameChanger.Script@,
+@GameChanger.Encoding@, @GameChanger.Intent@, @GameChanger.QR@,
+@GameChanger.Callback@). Each lands in its own ticket (#6–#12).
+-}
+module GameChanger (
+    version,
+) where
+
+import Data.Text (Text)
+
+{- | Current library version, hard-coded to match the cabal file.
+
+Downstream tickets will replace this with a Paths_-derived value
+once there is non-trivial content to version.
+-}
+version :: Text
+version = "0.1.0.0"

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,0 +1,21 @@
+{- | Test entry point. Skeleton stub: one trivial assertion to keep
+the test-suite derivation honest. Real tests arrive with the
+modules they cover (tickets #6–#14).
+-}
+module Main (
+    main,
+) where
+
+import qualified Data.Text as T
+import GameChanger (version)
+import Test.Tasty (defaultMain, testGroup)
+import Test.Tasty.HUnit (assertBool, testCase)
+
+main :: IO ()
+main =
+    defaultMain $
+        testGroup
+            "haskell-gamechanger"
+            [ testCase "version is non-empty" $
+                assertBool "version should not be empty" (not (T.null version))
+            ]


### PR DESCRIPTION
Tracks ticket [#5](https://github.com/lambdasistemi/haskell-gamechanger/issues/5). Implementation complete per `tasks.md` — ready for review after CI green.

## Status

- [x] Spec
- [x] Plan
- [x] Quickstart
- [x] Task list
- [x] Phase 1 — cabal project + CLAUDE.md + `.gitignore`
- [x] Phase 2 — `haskell.nix` project + src/app/test stubs + `justfile` + LICENSE
- [x] Phase 3 (US1) — `just build` / `just test` green locally
- [x] Phase 4 (US2) — real CI Build Gate (build-gate → tests + lint + docs)
- [x] Phase 5 (US3) — `just ci` runs all gates in order
- [x] Phase 6 (US4) — `nix flake show` exposes `packages` / `devShells` / `apps` / `checks`
- [ ] Phase 7 (US5) — Docs CI stays green (verified post-push)
- [ ] Phase 8 — ready-for-review + merge

## Artefacts

- [spec.md](https://github.com/lambdasistemi/haskell-gamechanger/blob/feat/issue-5-skeleton/specs/001-haskell-project-skeleton/spec.md)
- [plan.md](https://github.com/lambdasistemi/haskell-gamechanger/blob/feat/issue-5-skeleton/specs/001-haskell-project-skeleton/plan.md)
- [quickstart.md](https://github.com/lambdasistemi/haskell-gamechanger/blob/feat/issue-5-skeleton/specs/001-haskell-project-skeleton/quickstart.md)
- [tasks.md](https://github.com/lambdasistemi/haskell-gamechanger/blob/feat/issue-5-skeleton/specs/001-haskell-project-skeleton/tasks.md)

## Summary

Stand up a minimal Haskell library + `hgc` executable + test suite backed by `haskell.nix` (GHC 9.12.3), a `justfile` with the gate recipes the workflow skill expects, and a CI workflow using the Build Gate pattern so self-hosted `nixos` runners do not deadlock on the shared Nix store.

No domain code lands. The library exposes one placeholder `GameChanger.version`. Ticket #6 can land its first `GameChanger.Script` module by editing only cabal + `src/` — no flake, justfile, or CI edits required.

## What's in the tree

| Path | Purpose |
|------|---------|
| `haskell-gamechanger.cabal` | Single-package cabal, three stanzas (library, exe `hgc`, test-suite) |
| `cabal.project` | pins `index-state` to 2026-04-19 for both Hackage and CHaP |
| `src/GameChanger.hs` | `version :: Text` placeholder |
| `app/Main.hs` | prints `hgc <version>` |
| `test/Spec.hs` | one tasty-hunit smoke test |
| `flake.nix` | thin wrapper: inputs + per-system outputs |
| `nix/project.nix` | `haskell.nix` `cabalProject'` on GHC 9.12.3, CHaP input map, per-tool `cabal-fmt` pinned to ghc984 |
| `nix/checks.nix` | `library / exe / tests / lint` derivations |
| `nix/apps.nix` | runnable wrappers: `nix run .#hgc / .#tests / .#lint` |
| `justfile` | `build / test / format / format-check / hlint / lint / ci` + docs recipes |
| `.github/workflows/ci.yml` | Build Gate → fan-out (Tests, Lint, Docs) |
| `CLAUDE.md` | bootstraps Claude Code sessions with workflow skill + constitution pointers |
| `LICENSE` | Apache-2.0 |

## Design calls (see plan §Design decisions)

- **D1** `haskell.nix` over `nixpkgs.haskellPackages` — aligns with cardano-utxo-csmt / haskell-csmt / mpfs / moog; enables shared Cachix cache.
- **D2** Single-package cabal — library + `hgc` exe + test suite in one cabal file.
- **D3** One `ci.yml` workflow — `build-gate` → fan-out (tests, lint, docs).
- **D4** `CLAUDE.md` at root — bootstraps future sessions with workflow skill + constitution.
- **D5** No release-please, dependabot, typos workflows in this ticket.
- **D6** `tasty` from day one — every downstream ticket will need property + golden tests.
- **Extra** `cabal-fmt` tool pinned to `compiler-nix-name = "ghc984"` because `cabal-fmt-0.1.12` does not build against `base-4.21` (GHC 9.12). Other tools (`fourmolu`, `hlint`, `cabal`) are on the default ghc9123.

## Reviewer verification recipe

```bash
gh pr checkout 15
nix develop -c just ci      # build + test + format-check + hlint
nix flake show              # confirm outputs shape
```

## Review focus

- Is the task decomposition vertical-enough? Each phase should leave behind a bisect-safe state.
- Does the flake output shape (`packages / devShells / apps / checks`) match what downstream tickets will consume?
- GHC 9.12.3 — any concern about `haskell.nix` cache coverage?
- The `cabal-fmt` ghc984 pin — acceptable workaround or should we vendor/patch instead?

## After merge

Unblocks [#6](https://github.com/lambdasistemi/haskell-gamechanger/issues/6) (Script types) and [#8](https://github.com/lambdasistemi/haskell-gamechanger/issues/8) (Intent surface) simultaneously per the issue-dependency graph.
