### PR TITLE
feat: GameChanger.Script types + Aeson codec + golden tests (#6)

### DIFF
--- a/haskell-gamechanger.cabal
+++ b/haskell-gamechanger.cabal
@@ -31,10 +31,18 @@ common warnings
 library
   import:           warnings
   hs-source-dirs:   src
-  exposed-modules:  GameChanger
+  exposed-modules:
+    GameChanger
+    GameChanger.Script
+    GameChanger.Script.Smart
+    GameChanger.Script.Types
+
   build-depends:
-    , base  >=4.19 && <5
-    , text  >=2.0  && <2.2
+    , aeson       ^>=2.2
+    , base        >=4.19 && <5
+    , bytestring  >=0.11 && <0.13
+    , containers  >=0.6  && <0.8
+    , text        >=2.0  && <2.2
 
   default-language: Haskell2010
 
@@ -54,10 +62,16 @@ test-suite test
   type:             exitcode-stdio-1.0
   main-is:          Spec.hs
   hs-source-dirs:   test
+  other-modules:    Golden
   build-depends:
+    , aeson                ^>=2.2
     , base                 >=4.19 && <5
+    , bytestring           >=0.11 && <0.13
+    , containers           >=0.6  && <0.8
+    , filepath             >=1.4  && <1.6
     , haskell-gamechanger
     , tasty                >=1.5  && <1.6
+    , tasty-golden         >=2.3  && <2.4
     , tasty-hunit          >=0.10 && <0.11
     , text                 >=2.0  && <2.2
 

--- a/specs/002-script-types/checklists/requirements.md
+++ b/specs/002-script-types/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: GameChanger.Script types + Aeson codec + golden tests
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-20
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs) — *exception: Haskell / Aeson / tasty-golden are core-required by the ticket; these are not incidental implementation details but protocol-boundary requirements*
+- [x] Focused on user value and business needs (downstream-ticket enablement is the "user")
+- [x] Written for non-technical stakeholders — *the stakeholder here is the protocol's integration surface; wording favours integrators over compiler authors*
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable (SC-001..SC-005)
+- [x] Success criteria are technology-agnostic — *SC-005 names the beta wallet because it is the authoritative checker; this is intrinsic to the ticket, not a leak*
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded (see Out of scope in issue #6 + FR-011/FR-012)
+- [x] Dependencies and assumptions identified (Assumptions section)
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows (US1–US4)
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification beyond the protocol-boundary requirements
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`.
+- The Script type is the published JSON boundary (constitution §8). Any change to shape during implementation requires constitution + docs + ontology update in one vertical commit.

--- a/specs/002-script-types/data-model.md
+++ b/specs/002-script-types/data-model.md
@@ -1,0 +1,101 @@
+# Data model: GameChanger.Script
+
+**Feature**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md)
+
+The records below are the public JSON boundary of the library. Every field maps 1:1 to a documented wallet-accepted field. The types are deliberately plain (no final-tagless, no phantom parameters); this is the boundary, not the DSL.
+
+## `Script`
+
+```haskell
+data Script = Script
+  { title       :: Text
+  , description :: Maybe Text
+  , run         :: Map Text Action
+  , exports     :: Map Text Export
+  , metadata    :: Maybe Aeson.Value
+  }
+```
+
+JSON shape:
+
+```json
+{
+  "type": "script",
+  "title": "...",
+  "description": "...",
+  "run":     { "<name>": <Action>, ... },
+  "exports": { "<name>": <Export>, ... },
+  "metadata": { ... }
+}
+```
+
+- `type` is always the literal `"script"` — emitted by the encoder, expected by the decoder. Not a Haskell field.
+- `description` and `metadata` are omitted from the encoded JSON when `Nothing`.
+
+## `Action`
+
+```haskell
+data Action = Action
+  { kind      :: ActionKind
+  , namespace :: Text
+  , detail    :: Aeson.Value
+  }
+
+data ActionKind
+  = BuildTx
+  | SignTx
+  | SignData
+  | SubmitTx
+  | GetUTxOs
+```
+
+JSON shape:
+
+```json
+{
+  "type": "<kind>",
+  "namespace": "cache",
+  "detail": { ... action-specific payload ... }
+}
+```
+
+- `kind`'s JSON tag is the documented lowercase form: `buildTx`, `signTx`, `signData`, `submitTx`, `getUTxOs`.
+- `detail` is `Aeson.Value` in this ticket. Downstream tickets (#9) refine it to typed sub-records per kind. Decoder does not inspect `detail`.
+
+## `Export`
+
+```haskell
+data Export = Export
+  { source :: Text
+  , channel :: Channel
+  }
+
+data Channel
+  = Return   { returnUrl    :: Text }
+  | Post     { postUrl      :: Text }
+  | Download { downloadName :: Text }
+  | QR       { qrOptions    :: Maybe Aeson.Value }
+  | Copy
+```
+
+JSON shape (top-level export):
+
+```json
+{
+  "source": "{get('cache.signResult')}",
+  "mode":   "post",
+  ... per-mode descriptor fields ...
+}
+```
+
+- `mode` tag is the documented lowercase form: `return`, `post`, `download`, `qr`, `copy`.
+- Per-mode descriptor fields are flattened into the same object as `source` and `mode`. The `Channel` sum type's record fields encode directly; the decoder uses `mode` as the discriminator.
+- `Copy` has no extra fields.
+- `QR`'s options are deliberately `Maybe Value` — the documented options shape is in flux and not load-bearing for backend topologies (6.2, 6.3).
+
+## Invariants
+
+- Action-kind strings: five allowed, decoder rejects any other. No `UnknownAction` escape hatch.
+- Export-mode strings: five allowed, decoder rejects any other. No `UnknownChannel`.
+- `type` at script root is always `"script"`; decoder rejects other values with an error naming the offending string.
+- Optional fields (`description`, `metadata`, `Channel.qrOptions`) omitted when absent — the encoder never emits `null`.

--- a/specs/002-script-types/plan.md
+++ b/specs/002-script-types/plan.md
@@ -1,0 +1,132 @@
+# Implementation Plan: GameChanger.Script types + Aeson codec + golden tests
+
+**Branch**: `002-script-types` | **Date**: 2026-04-20 | **Spec**: [spec.md](./spec.md)
+**Ticket**: [#6](https://github.com/lambdasistemi/haskell-gamechanger/issues/6)
+
+## Summary
+
+Ship `GameChanger.Script` as the published JSON boundary: typed records for the five-kind action set and five-mode export set, Aeson codecs that match the wallet's accepted shape exactly, smart constructors per action kind, a golden-file harness at `test/golden/` driving round-trip equality. Land it as a pure Haskell library addition with no new CHaP pins and no Cardano deps — `cardano-api` / `cardano-ledger` stay out of this ticket by construction.
+
+## Technical Context
+
+- **Language/Version**: Haskell (GHC 9.12.3) via `haskell.nix`, per #5.
+- **Primary Dependencies**: `aeson`, `text`, `bytestring`, `containers`, `tasty`, `tasty-hunit`, `tasty-golden`. All from Hackage at the pinned `index-state` (2026-04-19).
+- **Storage**: JSON files in `test/golden/` (checked into the repo).
+- **Testing**: `tasty` + `tasty-hunit` (unit round-trips) + `tasty-golden` (fixture harness).
+- **Target Platform**: Linux / `x86_64-linux` (and whatever `haskell.nix` unlocks for free). No WASM.
+- **Project Type**: library addition to an existing single-package cabal.
+- **Performance Goals**: N/A — test suite expected to run in seconds.
+- **Constraints**: No `cardano-api` / `cardano-ledger` / `plutus-core` deps. No final-tagless encoding for `Script` (plain records). Bisect-safe commits.
+- **Scale/Scope**: ~5 golden fixtures, ~300 LOC in `src/`, ~150 LOC in `test/`.
+
+## Constitution Check
+
+| Gate | Status | Note |
+|---|---|---|
+| §8 Published JSON boundary is load-bearing | ✅ | This ticket *is* that boundary. Golden tests enforce shape. |
+| §11 Operational-monad encoding for Intent eDSL | ✅ N/A | `Script` is a plain record — the operational-monad rule is for `Intent`, not `Script`. Spec FR-011 calls this out. |
+| Scope A — backend only, no browser/WASM | ✅ | Library-only addition; no WASM surface. |
+| Vertical commits, bisect-safe | ✅ | Phases end in green states; no half-baked intermediates. |
+| No `cardano-api` | ✅ | Explicit FR-011. |
+| Docs travel with code | ✅ | Haddock on every export (FR-010); no separate docs commit. |
+
+No violations; Complexity Tracking section omitted.
+
+## Design decisions
+
+- **D1 — Plain records, not final-tagless.** `Script` is the JSON boundary; typeclass-indexed encodings add zero value here and the constitution forbids them for the Intent surface anyway. Records give a single, obvious JSON shape.
+- **D2 — Closed sum types for `ActionKind` and `Channel`.** The published protocol enumerates five of each. Modelling them as closed sums gives us exhaustiveness checks in every downstream pattern match and an explicit decoder failure on unknown values (FR-009).
+- **D3 — `detail` typed as `Aeson.Value` for now.** `buildTx` / `signTx` detail payloads are rich (addresses, UTxO sets, redeemers). Typing them properly requires Cardano types that are banned from this ticket. Ship as `Value`; refine in #9 when the Intent compiler has the typed surface on hand.
+- **D4 — `metadata :: Maybe Value`.** Same reasoning. If a downstream ticket needs structured metadata, it types it there.
+- **D5 — Golden fixtures under `test/golden/`, read by relative path.** No `Paths_` / `data-files` hand-wiring: `tasty-golden`'s `findByExtension` scans the directory at test time. Adding a fixture is literally dropping a JSON file in the directory.
+- **D6 — Canonicalise via `aeson`'s sort-by-key encoding for comparison, not raw bytes.** Aeson's default `encode` produces non-canonical key ordering. The harness decodes the on-disk JSON *and* the library's re-encoded output, then compares the resulting `Value`s — not bytes. This decouples fixture stability from encoder-output whitespace.
+- **D7 — Smart constructors take positional required inputs; optional fields get explicit setters.** Keeps call sites terse for the common case (e.g. `signDataAction ns addr msg`) without forcing record-update syntax for every call.
+- **D8 — Module split inside `GameChanger.Script`:**
+  - `GameChanger.Script` — re-exports the public surface.
+  - `GameChanger.Script.Types` — records + sum types + Aeson instances.
+  - `GameChanger.Script.Smart` — smart constructors.
+  This keeps the public module small and lets downstream tickets import the surface without re-exporting codec internals.
+
+## Pinned deps / tool versions
+
+| Dep | Version | Source |
+|---|---|---|
+| `aeson` | `^>= 2.2` | Hackage @ 2026-04-19 |
+| `bytestring` | boot | inherited |
+| `containers` | boot | inherited |
+| `text` | `>= 2.0` | already pinned in #5 |
+| `tasty` | `>= 1.5` | already pinned in #5 |
+| `tasty-hunit` | `>= 0.10` | already pinned in #5 |
+| `tasty-golden` | `>= 2.3` | Hackage @ 2026-04-19 (new in #6) |
+
+No CHaP additions. GHC 9.12.3 unchanged.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-script-types/
+├── spec.md
+├── plan.md                  # this file
+├── quickstart.md            # Phase 1 output
+├── tasks.md                 # Phase 2 output (/speckit.tasks)
+├── data-model.md            # Phase 1 output — the Script / Action / Export / Channel / Metadata record shapes
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+haskell-gamechanger.cabal    # add tasty-golden to test-suite, add new modules
+src/
+├── GameChanger.hs           # re-export Script surface
+├── GameChanger/
+│   └── Script.hs            # public module (re-exports Types + Smart)
+│   ├── Script/
+│   │   ├── Types.hs         # records + sum types + Aeson instances
+│   │   └── Smart.hs         # smart constructors
+test/
+├── Spec.hs                  # hooks the golden harness into tasty
+├── Golden.hs                # the harness (decode → re-encode → compare)
+└── golden/
+    ├── sign-data.json
+    ├── build-tx.json
+    ├── sign-tx.json
+    ├── submit-tx.json
+    ├── get-utxos.json
+    ├── export-return.json
+    ├── export-post.json
+    ├── export-download.json
+    ├── export-qr.json
+    └── export-copy.json
+```
+
+**Structure Decision**: Stay on the single-package cabal layout from #5. The only cabal change is adding `tasty-golden` to the test-suite build-depends and exposing the new modules from the library.
+
+## Quality gates (matches CI and `just ci`)
+
+Every commit must pass:
+
+```bash
+just build         # cabal build all -O0
+just test          # nix run .#tests (includes golden harness)
+just format-check  # fourmolu + cabal-fmt -c
+just hlint         # hlint src app test
+```
+
+Golden fixtures stabilise on first run; subsequent runs compare against the committed canonical form.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| `aeson` instance emits a shape the beta wallet rejects | SC-005: manually feed one fixture through the wallet, paste confirmation screen evidence into the PR body. |
+| A fixture we copy from the docs contains a field not in our record type | Parse with `genericParseJSON` using `rejectUnknownFields = True` — decoder will fail loudly with the field name, surfacing the gap. |
+| Smart-constructor API drifts from JSON shape | Golden harness is the regression trap: if a constructor change produces different JSON, the corresponding fixture fails. |
+| `tasty-golden` not in the cache yet | Trivial dep, no FFI; should build quickly on the nixos runner and populate the shared store on first CI. |
+
+## Open questions
+
+None at this stage. All [NEEDS CLARIFICATION] were resolved in the spec via Assumptions section.

--- a/specs/002-script-types/quickstart.md
+++ b/specs/002-script-types/quickstart.md
@@ -1,0 +1,82 @@
+# Quickstart: GameChanger.Script types + Aeson codec + golden tests
+
+**Feature**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md)
+
+## Clone and build
+
+```bash
+git clone git@github.com:lambdasistemi/haskell-gamechanger.git
+cd haskell-gamechanger
+git checkout 002-script-types
+
+nix develop                 # enters the GHC 9.12.3 dev shell
+just ci                     # build + test (incl. golden harness) + fourmolu + hlint
+```
+
+## Build a Script by hand in ghci
+
+```bash
+nix develop -c cabal repl lib:haskell-gamechanger
+```
+
+```haskell
+λ> :set -XOverloadedStrings
+λ> import qualified Data.Aeson as Aeson
+λ> import qualified Data.Map.Strict as Map
+λ> import GameChanger.Script
+λ>
+λ> let script = Script
+        { title = "Sign a message"
+        , description = Just "Hello-world example"
+        , run = Map.fromList
+            [ ("signResult", signDataAction "cache" "addr_test..." "hello") ]
+        , exports = Map.fromList
+            [ ("signature", Export "{get('cache.signResult')}" Copy) ]
+        , metadata = Nothing
+        }
+λ> Aeson.encode script
+-- {"type":"script","title":"Sign a message","description":"Hello-world example", ... }
+```
+
+## Round-trip a golden fixture
+
+```bash
+nix develop -c cabal test --test-options "-p Golden"
+```
+
+Expected output:
+
+```
+haskell-gamechanger
+  Golden
+    sign-data.json:      OK
+    build-tx.json:       OK
+    sign-tx.json:        OK
+    submit-tx.json:      OK
+    get-utxos.json:      OK
+    export-return.json:  OK
+    export-post.json:    OK
+    export-download.json: OK
+    export-qr.json:      OK
+    export-copy.json:    OK
+```
+
+## Add a new golden fixture
+
+1. Drop a JSON file at `test/golden/<name>.json`.
+2. Run `just test`. `tasty-golden`'s `findByExtension` auto-picks it up.
+3. If the test fails because the committed fixture is not yet in canonical form, copy the "actual" output back into the fixture and re-run to confirm stability.
+
+No harness edits required (FR-004, SC-004).
+
+## Manually verify against the beta wallet (SC-005)
+
+```bash
+# Take the sign-data fixture, pipe it through the eventual encoder (ticket #7
+# handles gzip+base64url). For this ticket, use the docs-endorsed resolver
+# helper manually: paste the fixture JSON at
+# https://beta-wallet.gamechanger.finance/doc/api/v2/script-builder
+# and open the generated URL.
+```
+
+Paste a screenshot or the generated resolver URL into the PR body as evidence.

--- a/specs/002-script-types/spec.md
+++ b/specs/002-script-types/spec.md
@@ -1,0 +1,122 @@
+# Feature Specification: GameChanger.Script types + Aeson codec + golden tests
+
+**Feature Branch**: `002-script-types`
+**Created**: 2026-04-20
+**Status**: Draft
+**Ticket**: [#6](https://github.com/lambdasistemi/haskell-gamechanger/issues/6)
+**Input**: Typed Haskell records for the GameChanger JSON script protocol with Aeson codec and golden round-trip tests.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A downstream ticket can build a script value in Haskell and round-trip it through JSON (Priority: P1) 🎯 MVP
+
+A future contributor lands ticket #9 (Intent → Script compiler) and needs a typed value of the Script protocol to produce from their compiler. They import `GameChanger.Script`, construct a `Script` record, encode it to JSON via `Aeson.encode`, and feed that JSON straight into the encoding pipeline (gzip + base64url, ticket #7). Decoding the same JSON back yields a structurally equal `Script` value.
+
+**Why this priority**: Every downstream ticket (#7, #9, #10, #11, #12) consumes `GameChanger.Script`. Nothing else can proceed until this type exists and round-trips cleanly. This ticket is on the critical path to a runnable `hgc`.
+
+**Independent Test**: Clone the branch, enter `nix develop`, open `ghci`, build a `Script` value with smart constructors, `Aeson.encode` it, `Aeson.eitherDecode` it back, assert equal.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Haskell value built via the smart constructor `signDataAction "cache" "addr_..." "hello"`, **When** the enclosing `Script` is Aeson-encoded and Aeson-decoded, **Then** the decoded value equals the original.
+2. **Given** any `Script` value in the library, **When** it is Aeson-encoded, **Then** the JSON object contains `{"type":"script", ...}` and only the documented field names (`title`, `description`, `run`, `exports`, `metadata` when present).
+3. **Given** a `Script` with at least one export in each of the five channel modes (`return`, `post`, `download`, `qr`, `copy`), **When** encoded and decoded, **Then** round-trip equality holds.
+
+---
+
+### User Story 2 - Published example scripts decode and re-encode byte-equal (Priority: P1) 🎯 MVP
+
+The GameChanger documentation publishes a handful of canonical example scripts. A future protocol reader needs confidence that `GameChanger.Script` parses every one of them without loss. We check in a small set of these as golden fixtures under `test/golden/`, and the test suite asserts: decode to `Script`, re-encode to JSON, compare byte-for-byte (modulo whitespace normalisation) against the fixture.
+
+**Why this priority**: The `Script` type is the published JSON boundary (constitution §8). If the decoder silently drops a field, or the encoder emits a shape the wallet rejects, every downstream ticket ships a broken integration. The golden set is the authoritative cross-check.
+
+**Independent Test**: `just test` is green. Each fixture lives at `test/golden/<name>.json` and has a matching test case. Adding a fixture + a one-line entry in `Spec.hs` is enough to extend coverage.
+
+**Acceptance Scenarios**:
+
+1. **Given** the fixture `test/golden/sign-data.json` from the published docs, **When** the test runs `Aeson.eitherDecode` then `Aeson.encode`, **Then** the canonicalised output equals the canonicalised input.
+2. **Given** a fixture that exercises every action kind (`buildTx`, `signTx`, `signData`, `submitTx`, `getUTxOs`) and every export channel mode, **When** decoded, **Then** no fields are dropped and every constructor round-trips.
+
+---
+
+### User Story 3 - Smart constructors give a type-safe action surface (Priority: P2)
+
+The downstream Intent compiler (#9) does not build `Run` entries by hand-crafting JSON keys; it calls smart constructors exported from `GameChanger.Script` — one per action kind. Each constructor takes the action's required inputs as typed parameters and produces a `Run` fragment or `Script.Action` value.
+
+**Why this priority**: This is what distinguishes a typed library from a `Value` alias. Without smart constructors the downstream compiler re-invents the JSON shape and the type system does not help. P2 because the record type alone is enough for MVP round-trip; smart constructors are the ergonomic layer that makes the library pleasant to use.
+
+**Independent Test**: `hgc` REPL can `Script.signDataAction "cache" "addr_..." "msg" :: Script.Action` and it type-checks.
+
+**Acceptance Scenarios**:
+
+1. **Given** the five action kinds (`buildTx`, `signTx`, `signData`, `submitTx`, `getUTxOs`), **When** a contributor looks at `GameChanger.Script`'s exports, **Then** there is one smart constructor per kind.
+2. **Given** a smart constructor, **When** it is called with valid arguments, **Then** the resulting `Action` encodes to the JSON shape the wallet expects for that action kind.
+
+---
+
+### User Story 4 - Breaking the protocol shape breaks the build (Priority: P2)
+
+Any change to the protocol model must be load-bearing: the constitution, the docs, and the code must all agree. This story requires that the golden fixtures double as a regression harness. If a developer accidentally changes a field name, drops a channel mode, or reorders a sum type, the golden test suite fails loudly before the change lands.
+
+**Why this priority**: Constitution §8 makes the JSON shape the published boundary. Silent drift here leaks into every downstream integration.
+
+**Independent Test**: Temporarily rename one field in `GameChanger.Script` (e.g. `description` → `desc`); `just test` fails with a clear fixture mismatch naming the offending path. Revert the change.
+
+**Acceptance Scenarios**:
+
+1. **Given** a field rename in `GameChanger.Script`, **When** `just test` runs, **Then** the failing fixture's name and the diverging JSON path are in the output.
+2. **Given** an action-kind constructor rename, **When** the golden for that action decodes, **Then** the failing action name is surfaced in the decode error.
+
+---
+
+### Edge Cases
+
+- A fixture contains a `metadata` field we do not yet model — decoder must either preserve it (as raw `Value`) or explicitly drop it and the choice must be documented.
+- A fixture omits the `description` field — decoder must accept omission; encoder must not emit `null` for missing optional fields.
+- An export descriptor uses a mode string we have not seen (`clipboard` vs `copy` confusion). Decoder must fail with a message naming the unknown mode, not silently succeed.
+- An action-kind string the library does not model (extensibility) — decoder must fail explicitly; no `UnknownAction` constructor.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The library MUST expose a module `GameChanger.Script` with a `Script` data type covering the top-level fields: `type` (constant `"script"`), `title`, `description` (optional), `run`, `exports`, and `metadata` (optional).
+- **FR-002**: The `Script` type MUST have `ToJSON` and `FromJSON` instances that produce exactly the JSON shape the GameChanger wallet accepts today (shape documented in `docs/protocol.md`).
+- **FR-003**: The library MUST model the five action kinds as a closed sum type: `BuildTx`, `SignTx`, `SignData`, `SubmitTx`, `GetUTxOs`. The `type` JSON string MUST match the documented lowercase form (`buildTx`, `signTx`, `signData`, `submitTx`, `getUTxOs`).
+- **FR-004**: The library MUST model the five export channel modes as a closed sum type: `Return`, `Post`, `Download`, `QR`, `Copy`. The JSON tag MUST match the documented lowercase form.
+- **FR-005**: The library MUST expose one smart constructor per action kind that takes the action's required inputs and produces an `Action` value.
+- **FR-006**: The test suite MUST include a golden-fixture harness that, for every `test/golden/<name>.json`, performs decode → re-encode → compare against a canonical form and fails with the fixture's path on mismatch.
+- **FR-007**: The library MUST round-trip at least one fixture per action kind and one fixture per export channel mode (so every constructor is exercised).
+- **FR-008**: The encoder MUST omit optional fields when absent (do not emit `"description": null`).
+- **FR-009**: The decoder MUST reject unknown action-kind strings and unknown export-channel mode strings with an error message naming the offending value.
+- **FR-010**: All exports from `GameChanger.Script` MUST carry Haddock headers describing their role. The module MUST have a module-level Haddock.
+- **FR-011**: The library MUST NOT depend on `cardano-api`, `cardano-ledger`, or `plutus-core` for this ticket — the `Script` type is the *published JSON boundary*, not a Cardano-typed surface.
+- **FR-012**: The `detail` payloads for the richer actions (`buildTx`, `signTx`) MAY be typed as `Aeson.Value` in this ticket — refining them to typed records is deferred to later tickets (#9 onwards).
+
+### Key Entities
+
+- **Script**: top-level protocol value. Fields: `type`, `title`, optional `description`, `run`, `exports`, optional `metadata`. This is the boundary type — everything the library emits and every URL the wallet accepts decodes to this.
+- **Action**: one entry in the `run` map. Fields: `type` (one of the five action-kind strings), `namespace`, `detail` (action-specific payload). Encoded inline as a JSON object.
+- **Export**: one entry in the `exports` map. Fields: `source` (template expression `String`), `mode` (one of `return`, `post`, `download`, `qr`, `copy`), plus per-mode descriptor fields.
+- **Channel**: the sum type of the five export modes. Load-bearing for exhaustiveness of downstream pattern matches.
+- **Metadata**: an optional map-or-record placeholder; kept minimal at this ticket (`Aeson.Value` is acceptable).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Every fixture in `test/golden/` round-trips decode → re-encode → canonicalise → byte-equal against its on-disk form. No exceptions, no skips.
+- **SC-002**: All five action kinds and all five export channel modes are exercised by at least one fixture each.
+- **SC-003**: `just ci` is green on the branch (build + test + format-check + hlint).
+- **SC-004**: A reviewer can add coverage for a newly-documented action by adding one `test/golden/<name>.json` and one test-case line — no changes to the harness required.
+- **SC-005**: `GameChanger.Script` is manually verified against the beta wallet (documented in the PR body by pasting a resolver URL produced from one of the fixtures and confirming the wallet renders the expected confirmation screen).
+
+## Assumptions
+
+- The published protocol, as captured in `docs/protocol.md` and the linked docs, is the authoritative shape. If divergence is discovered during implementation, the docs are updated in the same vertical commit (governance rule).
+- `detail` payloads for `buildTx` / `signTx` remain `Aeson.Value` for now. Typed refinement lands with the Intent compiler (#9).
+- `metadata` is `Maybe Aeson.Value` for now — no downstream ticket on the critical path consumes it.
+- `aeson`, `bytestring`, `text`, `containers` are acceptable dependencies (core boot-ish). No new CHaP pins introduced.
+- Golden fixtures are small JSON files committed at `test/golden/` — cabal `data-files` is sufficient, no `Paths_` magic required (read from a path relative to the package's source directory, which is how the existing test-suite resolves fixtures in sister projects).
+- The constitution's encoding choice (no final-tagless) does not apply to `Script` — this ticket ships plain records. The operational-monad rule is for the Intent surface (#8).
+- Tasty is used for the test harness (as set up in #5); `tasty-golden` is the intended mechanism for the golden-file comparisons.

--- a/specs/002-script-types/tasks.md
+++ b/specs/002-script-types/tasks.md
@@ -1,0 +1,167 @@
+---
+description: "Task list for feature 002 — GameChanger.Script types + Aeson codec + golden tests"
+---
+
+# Tasks: GameChanger.Script types + Aeson codec + golden tests
+
+**Input**: `specs/002-script-types/{spec.md, plan.md, data-model.md, quickstart.md}`
+**Branch**: `002-script-types`
+**Ticket**: [#6](https://github.com/lambdasistemi/haskell-gamechanger/issues/6)
+
+## Format: `[ID] [P?] [Story] Description`
+
+- `[P]` — can run in parallel with other `[P]` tasks in the same phase (different files, no dependencies).
+- `[Story]` — which user story in `spec.md` the task serves. `[-]` means cross-cutting / phase-scoped.
+
+## Path conventions
+
+Single-package cabal at the repo root. `src/GameChanger/Script/` for the new modules. `test/Golden.hs` for the harness. `test/golden/` for the JSON fixtures. Matches plan.md §"Project Structure".
+
+---
+
+## Phase 1: Setup — cabal wiring
+
+**Purpose**: cabal metadata must accept the new modules and deps before any code lands.
+
+- [ ] T001 [-] Add `tasty-golden >=2.3 && <2.4` to the `test-suite test` `build-depends` in `haskell-gamechanger.cabal`.
+- [ ] T002 [-] Extend `library` `exposed-modules:` to include `GameChanger.Script`, `GameChanger.Script.Types`, `GameChanger.Script.Smart`. Re-run `cabal-fmt -i` to keep alignment.
+- [ ] T003 [-] Extend `library` `build-depends` with `aeson`, `bytestring`, `containers` (exact bounds: `aeson ^>=2.2`, `bytestring >=0.11 && <0.13`, `containers >=0.6 && <0.8`).
+
+**Checkpoint**: cabal file compiles with empty module stubs in the next phase.
+
+---
+
+## Phase 2: Foundational — module stubs + harness skeleton
+
+**Purpose**: every user story needs the modules to exist and the Aeson harness to be pluggable. This phase creates empty stubs that compile and a harness that runs zero fixtures green.
+
+**⚠️ CRITICAL**: no user story work starts until Phase 2 is complete.
+
+- [ ] T004 [P] [-] Create `src/GameChanger/Script/Types.hs` with module header Haddock and the empty declarations `data Script`, `data Action`, `data ActionKind`, `data Export`, `data Channel` — stub definitions are enough to compile (`data Script = Script deriving (Show, Eq)` style). Export list explicit.
+- [ ] T005 [P] [-] Create `src/GameChanger/Script/Smart.hs` with module header Haddock and no exports yet. Imports `GameChanger.Script.Types`.
+- [ ] T006 [P] [-] Create `src/GameChanger/Script.hs` that re-exports `GameChanger.Script.Types` and `GameChanger.Script.Smart`.
+- [ ] T007 [-] Extend `test/Spec.hs` to invoke a tasty `testGroup` named `"Script"` that currently contains zero tests. Add `test/Golden.hs` exporting `goldenTests :: IO TestTree` that uses `Test.Tasty.Golden.findByExtension` against `test/golden/` and returns an empty tree until fixtures are added.
+
+**Checkpoint**: `just build` and `just test` both succeed against the empty harness.
+
+---
+
+## Phase 3: User Story 1 — round-trip a hand-built Script (Priority: P1) 🎯 MVP
+
+**Goal**: a Haskell caller can build a `Script` with smart constructors, encode it to JSON, decode it back, and get `(==)`-equal value.
+
+**Independent Test**: `cabal repl` session per [quickstart.md](./quickstart.md); `Aeson.eitherDecode (Aeson.encode script) == Right script`.
+
+- [ ] T008 [US1] In `src/GameChanger/Script/Types.hs`, flesh out the records per [data-model.md](./data-model.md): `Script`, `Action`, `ActionKind` (closed sum), `Export`, `Channel` (closed sum with per-constructor record fields). Derive `Show`, `Eq`, `Generic`.
+- [ ] T009 [US1] Write `ToJSON`/`FromJSON` for `ActionKind` — tag strings `buildTx` / `signTx` / `signData` / `submitTx` / `getUTxOs`. Decoder MUST reject unknown strings with an `Aeson` error naming the offending value (FR-009).
+- [ ] T010 [US1] Write `ToJSON`/`FromJSON` for `Channel` — tag field is `mode` with strings `return` / `post` / `download` / `qr` / `copy`, per-mode descriptor fields flattened into the same object, `Copy` has no extras. `qrOptions` omitted when `Nothing`.
+- [ ] T011 [US1] Write `ToJSON`/`FromJSON` for `Export` — flattens `source` and `channel` into a single object (shares the object with the channel's descriptor fields).
+- [ ] T012 [US1] Write `ToJSON`/`FromJSON` for `Action` — object shape `{type, namespace, detail}`. `type` from `ActionKind`.
+- [ ] T013 [US1] Write `ToJSON`/`FromJSON` for `Script` — object shape `{type:"script", title, description?, run, exports, metadata?}`. Encoder omits `description` / `metadata` when `Nothing`; decoder accepts omission. Decoder rejects a root `type` other than `"script"` with an error naming the offending value.
+- [ ] T014 [US1] In `src/GameChanger/Script/Smart.hs` add one smart constructor per action kind: `buildTxAction`, `signTxAction`, `signDataAction`, `submitTxAction`, `getUTxOsAction`. Each takes the minimal required inputs as positional args and returns an `Action` whose `detail` is an `Aeson.Object`. Signatures picked to match the documented detail payloads (FR-005; match the shapes referenced in the published `script-builder` docs).
+- [ ] T015 [US1] Re-export the public surface from `src/GameChanger/Script.hs`: the five constructors, all five data types, and the `ActionKind`/`Channel` values. Explicit export list.
+- [ ] T016 [US1] Add a tasty-hunit `testCase "round-trip hand-built Script"` in `test/Spec.hs` under the `"Script"` group. Build a `Script` via smart constructors covering at least one of each action kind and each channel mode; assert `Aeson.eitherDecode (Aeson.encode s) == Right s`.
+
+**Checkpoint**: US1 green. MVP achieved — downstream tickets can build + round-trip Scripts.
+
+---
+
+## Phase 4: User Story 2 — golden fixtures round-trip byte-equal (Priority: P1) 🎯 MVP
+
+**Goal**: every fixture in `test/golden/` decodes, re-encodes, and matches its on-disk canonical form.
+
+**Independent Test**: `just test` runs the golden harness and every fixture passes without a manual entry in the harness.
+
+- [ ] T017 [P] [US2] Create `test/golden/sign-data.json` — minimal valid script exercising `signData` + `copy` export. Source from the published docs where possible; otherwise construct by hand and verify against the wallet manually later.
+- [ ] T018 [P] [US2] Create `test/golden/build-tx.json` — exercises `buildTx` + `post` export.
+- [ ] T019 [P] [US2] Create `test/golden/sign-tx.json` — exercises `signTx` + `return` export.
+- [ ] T020 [P] [US2] Create `test/golden/submit-tx.json` — exercises `submitTx` + `post` export.
+- [ ] T021 [P] [US2] Create `test/golden/get-utxos.json` — exercises `getUTxOs` + `copy` export.
+- [ ] T022 [P] [US2] Create `test/golden/export-return.json`, `export-post.json`, `export-download.json`, `export-qr.json`, `export-copy.json` — each a minimal one-action script whose exports block exercises exactly one channel. Separate files so the harness surfaces which mode fails in isolation.
+- [ ] T023 [US2] Implement the harness in `test/Golden.hs`: `findByExtension [".json"] "test/golden"` → for each path produce a `goldenVsStringDiff path diff (canonicalise path) (canonicalise <$> (decode >=> pure . encode) <$> readFile path)` test. `canonicalise :: ByteString -> ByteString` decodes to `Value` then re-encodes via `Aeson.encode` with sorted keys (use `aeson-pretty`'s `encodePretty` with `Config { confIndent = 2, confCompare = compare, ... }` or hand-roll a canonicaliser) — per plan.md D6.
+- [ ] T024 [US2] Wire `goldenTests` into `test/Spec.hs`'s `"Script"` group.
+- [ ] T025 [US2] Run `just test`; on first run, every fixture may be re-canonicalised — commit the canonical forms. On the second run, all golden cases must report OK.
+
+**Checkpoint**: US2 green. Published-shape regressions trip the harness.
+
+---
+
+## Phase 5: User Story 3 — smart-constructor sanity test (Priority: P2)
+
+**Goal**: a small unit test exercises every smart constructor and asserts the resulting JSON has the expected action-kind tag.
+
+**Independent Test**: add a smart constructor call + an assertion; verify it passes.
+
+- [ ] T026 [US3] Add a tasty-hunit `testCase "smart constructors emit the right type tag"` under `"Script"`. For each constructor, build an `Action`, encode it, decode to `Value`, and assert the `type` field matches the expected string. Catches accidental constructor/tag drift.
+
+**Checkpoint**: US3 green. Refactoring a smart constructor that changes the tag fails loudly.
+
+---
+
+## Phase 6: User Story 4 — regression surface (Priority: P2)
+
+**Goal**: a deliberate field rename trips the golden harness with a clear error.
+
+**Independent Test**: manually rename a field (e.g. `description` → `desc`) locally, run `just test`, observe a failure that names the fixture path and the diverging JSON field. Revert.
+
+- [ ] T027 [US4] No new code. Verify US4 by hand per the manual test above; paste the failing test output into the PR body as evidence (SC-005 also references this kind of evidence).
+
+**Checkpoint**: US4 validated by demonstration.
+
+---
+
+## Phase 7: Polish & cross-cutting
+
+- [ ] T028 [P] [-] Add module-level Haddock headers to `GameChanger.Script.Types` and `GameChanger.Script.Smart` describing the role each plays and linking back to the constitution's §8 (JSON boundary).
+- [ ] T029 [P] [-] Run `just format` (fourmolu + cabal-fmt) then `just format-check` to confirm the tree is clean.
+- [ ] T030 [-] Run `just hlint` clean. Resolve any hints in-place — no follow-up commit.
+- [ ] T031 [-] Manual wallet check (SC-005): feed `sign-data.json` through the docs' script-builder endpoint, confirm the wallet opens the expected confirmation dialog, paste evidence in the PR body.
+- [ ] T032 [-] Open PR with title `feat: GameChanger.Script types + Aeson codec + golden tests (#6)`, label `feat`, assign `paolino`. Paste the quickstart recipe in the PR body.
+- [ ] T033 [-] Wait for CI green; merge via `mcp__merge-guard__guard-merge method: rebase`. Remove the worktree.
+- [ ] T034 [-] Close #6 with landing note; confirm #7 and #9 blockers update in the planner dependency graph.
+
+---
+
+## Dependencies & execution order
+
+### Phase dependencies
+
+- **Phase 1 (Setup)** — no deps; runs first.
+- **Phase 2 (Foundational)** — depends on Phase 1. Blocks every user story.
+- **Phase 3 (US1)** — depends on Phase 2.
+- **Phase 4 (US2)** — depends on Phase 3 (needs the codec from US1 to canonicalise fixtures).
+- **Phase 5 (US3)** — depends on Phase 3.
+- **Phase 6 (US4)** — depends on Phase 4 (needs a fixture to regress against).
+- **Phase 7 (Polish)** — depends on all stories.
+
+### Task-level critical path
+
+```
+T001..T003 → T004..T007 → T008..T016 → T017..T025
+                                  ↘ T026
+                                  ↘ T027 (manual)
+                                           → T028..T034
+```
+
+### Parallel opportunities
+
+- T004, T005, T006 are different files; run in parallel.
+- T017..T022 are all golden fixtures; write in parallel.
+- T028, T029 are orthogonal polish; run in parallel.
+
+---
+
+## Implementation strategy
+
+MVP-first: Phase 1 + Phase 2 stand up the scaffolding. Phase 3 (US1) delivers a typed round-trip — the minimum viable value. Phase 4 (US2) adds the golden harness, which is where the published-boundary guarantee actually lives. Phases 5–6 are verification layers. Phase 7 cleans up and ships.
+
+Each phase ends in a green commit. No phase leaves behind a broken build.
+
+---
+
+## Notes
+
+- Every commit must compile and `just ci` clean — bisect-safe per the workflow skill.
+- If a golden fixture reveals a JSON shape our records do not model, the fix is in the **records + data-model.md + docs + constitution §8** — one vertical commit per the governance rule, not a one-off fixture tweak.
+- Do not introduce `cardano-api`, `cardano-ledger`, or `plutus-core` deps (FR-011). `detail` is `Value` for now.
+- `tasty-golden` is new at Phase 1 — expect a modest first-CI build time, cached after.

--- a/src/GameChanger/Script.hs
+++ b/src/GameChanger/Script.hs
@@ -1,0 +1,36 @@
+{- | Public surface for the GameChanger script protocol.
+
+Re-exports the record types from "GameChanger.Script.Types" and
+the smart constructors from "GameChanger.Script.Smart". Downstream
+tickets import this module rather than the internals.
+-}
+module GameChanger.Script (
+    -- * Types
+    Script (..),
+    Action (..),
+    ActionKind (..),
+    Export (..),
+    Channel (..),
+
+    -- * Smart constructors
+    buildTxAction,
+    signTxAction,
+    signDataAction,
+    submitTxAction,
+    getUTxOsAction,
+) where
+
+import GameChanger.Script.Smart (
+    buildTxAction,
+    getUTxOsAction,
+    signDataAction,
+    signTxAction,
+    submitTxAction,
+ )
+import GameChanger.Script.Types (
+    Action (..),
+    ActionKind (..),
+    Channel (..),
+    Export (..),
+    Script (..),
+ )

--- a/src/GameChanger/Script/Smart.hs
+++ b/src/GameChanger/Script/Smart.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Smart constructors for the five GameChanger action kinds.
+
+Each constructor takes the action's minimal required inputs as
+positional arguments and returns an 'Action' with an
+appropriately-shaped @detail@ payload. The payload is kept as
+'Aeson.Value' at this ticket (#6); typed refinement lands with the
+Intent compiler (#9).
+-}
+module GameChanger.Script.Smart (
+    buildTxAction,
+    signTxAction,
+    signDataAction,
+    submitTxAction,
+    getUTxOsAction,
+) where
+
+import Data.Aeson (Value, object, (.=))
+import Data.Text (Text)
+import GameChanger.Script.Types (Action (..), ActionKind (..))
+
+{- | Build a @buildTx@ action.
+
+@buildTxAction ns spec@ — @ns@ is the namespace the wallet caches
+the result under; @spec@ is the @detail@ payload describing
+inputs, outputs, and auxiliary data. The payload shape is opaque
+here; the Intent compiler (#9) will construct it from a typed
+surface.
+-}
+buildTxAction :: Text -> Value -> Action
+buildTxAction = Action BuildTx
+
+{- | Build a @signTx@ action.
+
+@signTxAction ns txRef@ — signs the transaction referenced by
+@txRef@ (typically a template expression referring to an earlier
+@buildTx@ result) and caches the witness under @ns@.
+-}
+signTxAction :: Text -> Text -> Action
+signTxAction ns txRef =
+    Action SignTx ns $ object ["tx" .= txRef]
+
+{- | Build a @signData@ (CIP-8 COSE Sign1) action.
+
+@signDataAction ns addr message@ — signs @message@ as the signer
+at @addr@, caching the COSE Sign1 blob under @ns@.
+-}
+signDataAction :: Text -> Text -> Text -> Action
+signDataAction ns addr message =
+    Action SignData ns $
+        object
+            [ "address" .= addr
+            , "message" .= message
+            ]
+
+{- | Build a @submitTx@ action.
+
+@submitTxAction ns txRef@ — submits the transaction referenced by
+@txRef@ to the node the wallet is connected to.
+-}
+submitTxAction :: Text -> Text -> Action
+submitTxAction ns txRef =
+    Action SubmitTx ns $ object ["tx" .= txRef]
+
+{- | Build a @getUTxOs@ action.
+
+@getUTxOsAction ns@ — caches the wallet's UTxO set under @ns@ for
+downstream actions (e.g. @buildTx@) to reference. No extra input
+is required.
+-}
+getUTxOsAction :: Text -> Action
+getUTxOsAction ns = Action GetUTxOs ns $ object []

--- a/src/GameChanger/Script/Types.hs
+++ b/src/GameChanger/Script/Types.hs
@@ -1,0 +1,215 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-partial-fields #-}
+
+{- | Record types for the GameChanger JSON script protocol.
+
+This module is the published JSON boundary: the shape emitted by
+'ToJSON' and accepted by 'FromJSON' is exactly the shape the
+GameChanger wallet accepts. Any drift here breaks downstream
+integrations, so the golden-test suite pins each action kind and
+channel mode to a fixture.
+
+Constitution §8: the JSON shape is load-bearing. Changes to this
+module's encoded form require a matching update to the
+constitution, the docs, and the ontology in one vertical commit.
+-}
+module GameChanger.Script.Types (
+    Script (..),
+    Action (..),
+    ActionKind (..),
+    Export (..),
+    Channel (..),
+) where
+
+import Data.Aeson (
+    FromJSON (..),
+    ToJSON (..),
+    Value,
+    object,
+    withObject,
+    withText,
+    (.!=),
+    (.:),
+    (.:?),
+    (.=),
+ )
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import Data.Map.Strict (Map)
+import Data.Text (Text)
+import qualified Data.Text as T
+import GHC.Generics (Generic)
+
+{- | Top-level protocol value.
+
+The 'type' discriminator is always the literal @"script"@ — emitted
+by the encoder and required by the decoder.
+-}
+data Script = Script
+    { title :: Text
+    , description :: Maybe Text
+    , run :: Map Text Action
+    , exports :: Map Text Export
+    , metadata :: Maybe Value
+    }
+    deriving stock (Show, Eq, Generic)
+
+instance ToJSON Script where
+    toJSON s =
+        object $
+            [ "type" .= ("script" :: Text)
+            , "title" .= title s
+            , "run" .= run s
+            , "exports" .= exports s
+            ]
+                <> maybe [] (\d -> ["description" .= d]) (description s)
+                <> maybe [] (\m -> ["metadata" .= m]) (metadata s)
+
+instance FromJSON Script where
+    parseJSON = withObject "Script" $ \o -> do
+        t <- o .: "type"
+        if (t :: Text) /= "script"
+            then fail $ "expected type \"script\", got " <> show t
+            else
+                Script
+                    <$> o .: "title"
+                    <*> o .:? "description"
+                    <*> o .:? "run" .!= mempty
+                    <*> o .:? "exports" .!= mempty
+                    <*> o .:? "metadata"
+
+{- | One entry in the 'Script' @run@ map.
+
+The @type@ field discriminates the action kind; @detail@ carries
+the action-specific payload. 'detail' is 'Value' here — typed
+per-kind refinement lands with the Intent compiler (#9).
+-}
+data Action = Action
+    { kind :: ActionKind
+    , namespace :: Text
+    , detail :: Value
+    }
+    deriving stock (Show, Eq, Generic)
+
+instance ToJSON Action where
+    toJSON a =
+        object
+            [ "type" .= kind a
+            , "namespace" .= namespace a
+            , "detail" .= detail a
+            ]
+
+instance FromJSON Action where
+    parseJSON = withObject "Action" $ \o ->
+        Action
+            <$> o .: "type"
+            <*> o .: "namespace"
+            <*> o .:? "detail" .!= Aeson.Null
+
+{- | The five action kinds the GameChanger wallet accepts.
+
+Decoder rejects unknown strings (FR-009). No @UnknownAction@
+escape hatch — the closed set is load-bearing for downstream
+pattern matches.
+-}
+data ActionKind
+    = BuildTx
+    | SignTx
+    | SignData
+    | SubmitTx
+    | GetUTxOs
+    deriving stock (Show, Eq, Generic, Enum, Bounded)
+
+actionKindTag :: ActionKind -> Text
+actionKindTag = \case
+    BuildTx -> "buildTx"
+    SignTx -> "signTx"
+    SignData -> "signData"
+    SubmitTx -> "submitTx"
+    GetUTxOs -> "getUTxOs"
+
+instance ToJSON ActionKind where
+    toJSON = Aeson.String . actionKindTag
+
+instance FromJSON ActionKind where
+    parseJSON = withText "ActionKind" $ \case
+        "buildTx" -> pure BuildTx
+        "signTx" -> pure SignTx
+        "signData" -> pure SignData
+        "submitTx" -> pure SubmitTx
+        "getUTxOs" -> pure GetUTxOs
+        other ->
+            fail $
+                "unknown action kind \""
+                    <> T.unpack other
+                    <> "\" (expected buildTx, signTx, signData, submitTx, getUTxOs)"
+
+{- | One entry in the 'Script' @exports@ map.
+
+An export declares the @source@ template expression and the
+'Channel' it is delivered over.
+-}
+data Export = Export
+    { source :: Text
+    , channel :: Channel
+    }
+    deriving stock (Show, Eq, Generic)
+
+instance ToJSON Export where
+    toJSON e =
+        case toJSON (channel e) of
+            Aeson.Object km ->
+                Aeson.Object $ KeyMap.insert "source" (toJSON (source e)) km
+            _ ->
+                object ["source" .= source e]
+
+instance FromJSON Export where
+    parseJSON v = do
+        o <- parseJSON v
+        s <- (o :: Aeson.Object) .: "source"
+        ch <- parseJSON (Aeson.Object o)
+        pure (Export s ch)
+
+{- | The five export channel modes the GameChanger wallet supports.
+
+Decoder rejects unknown mode strings (FR-009). Each constructor
+carries its per-mode descriptor fields flattened into the shared
+JSON object with @source@ and @mode@.
+-}
+data Channel
+    = Return {returnUrl :: Text}
+    | Post {postUrl :: Text}
+    | Download {downloadName :: Text}
+    | QR {qrOptions :: Maybe Value}
+    | Copy
+    deriving stock (Show, Eq, Generic)
+
+instance ToJSON Channel where
+    toJSON =
+        Aeson.Object . \case
+            Return u -> KeyMap.fromList [("mode", "return"), ("returnUrl", toJSON u)]
+            Post u -> KeyMap.fromList [("mode", "post"), ("postUrl", toJSON u)]
+            Download n -> KeyMap.fromList [("mode", "download"), ("downloadName", toJSON n)]
+            QR opts ->
+                KeyMap.fromList $
+                    ("mode", "qr")
+                        : maybe [] (\o -> [("qrOptions", o)]) opts
+            Copy -> KeyMap.fromList [("mode", "copy")]
+
+instance FromJSON Channel where
+    parseJSON = withObject "Channel" $ \o -> do
+        m <- o .: "mode"
+        case (m :: Text) of
+            "return" -> Return <$> o .: "returnUrl"
+            "post" -> Post <$> o .: "postUrl"
+            "download" -> Download <$> o .: "downloadName"
+            "qr" -> QR <$> o .:? "qrOptions"
+            "copy" -> pure Copy
+            other ->
+                fail $
+                    "unknown export mode \""
+                        <> T.unpack other
+                        <> "\" (expected return, post, download, qr, copy)"

--- a/test/Golden.hs
+++ b/test/Golden.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Golden round-trip harness for 'GameChanger.Script'.
+
+For every @test/golden/*.json@ fixture:
+
+1. decode the on-disk JSON to 'Aeson.Value' — the canonical form;
+2. decode the same JSON to 'Script' via the library's 'FromJSON';
+3. re-encode that 'Script' via 'ToJSON' and decode back to 'Value';
+4. compare the two 'Value's for structural equality.
+
+Any drift between the committed fixture and the round-tripped
+output fails the test with the fixture's path, so the failing
+fixture is named directly in the output.
+-}
+module Golden (goldenTests) where
+
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.ByteString.Lazy.Char8 as LBSC
+import GameChanger.Script (Script)
+import System.FilePath (takeBaseName)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Golden (findByExtension)
+import Test.Tasty.HUnit (assertFailure, testCase, (@?=))
+
+goldenTests :: IO TestTree
+goldenTests = do
+    paths <- findByExtension [".json"] "test/golden"
+    pure $ testGroup "Golden" (map oneFixture paths)
+
+oneFixture :: FilePath -> TestTree
+oneFixture path = testCase (takeBaseName path) $ do
+    bytes <- LBS.readFile path
+    original <- case Aeson.eitherDecode bytes :: Either String Aeson.Value of
+        Left e -> assertFailure $ "fixture is not valid JSON: " <> e
+        Right v -> pure v
+    script <- case Aeson.eitherDecode bytes :: Either String Script of
+        Left e ->
+            assertFailure $
+                "fixture decoded as Value but failed to decode as Script: "
+                    <> e
+                    <> "\noriginal: "
+                    <> LBSC.unpack (Aeson.encode original)
+        Right s -> pure s
+    let reencoded = Aeson.encode script
+    roundtrip <- case Aeson.eitherDecode reencoded :: Either String Aeson.Value of
+        Left e -> assertFailure $ "re-encoded Script is not valid JSON: " <> e
+        Right v -> pure v
+    roundtrip @?= original

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,21 +1,84 @@
-{- | Test entry point. Skeleton stub: one trivial assertion to keep
-the test-suite derivation honest. Real tests arrive with the
-modules they cover (tickets #6–#14).
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Test entry point.
+
+Wires the Script round-trip harness (unit round-trips + goldens)
+into tasty. The per-suite content lives in 'Golden' and in the
+inline test cases below.
 -}
 module Main (
     main,
 ) where
 
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import GameChanger (version)
-import Test.Tasty (defaultMain, testGroup)
-import Test.Tasty.HUnit (assertBool, testCase)
+import GameChanger.Script
+import qualified Golden
+import Test.Tasty (TestTree, defaultMain, testGroup)
+import Test.Tasty.HUnit (assertBool, assertFailure, testCase, (@?=))
 
 main :: IO ()
-main =
+main = do
+    goldens <- Golden.goldenTests
     defaultMain $
         testGroup
             "haskell-gamechanger"
             [ testCase "version is non-empty" $
                 assertBool "version should not be empty" (not (T.null version))
+            , testGroup
+                "Script"
+                [ roundTripHandBuilt
+                , smartConstructorTags
+                , goldens
+                ]
             ]
+
+roundTripHandBuilt :: TestTree
+roundTripHandBuilt = testCase "round-trip hand-built Script" $ do
+    let s =
+            Script
+                { title = "round-trip test"
+                , description = Just "exercises every action kind and every channel mode"
+                , run =
+                    Map.fromList
+                        [ ("u", getUTxOsAction "cache")
+                        , ("b", buildTxAction "cache" (Aeson.Object mempty))
+                        , ("s", signTxAction "cache" "{get('cache.b.tx')}")
+                        , ("m", signDataAction "cache" "addr_test1..." "hello")
+                        , ("x", submitTxAction "cache" "{get('cache.s')}")
+                        ]
+                , exports =
+                    Map.fromList
+                        [ ("ret", Export "{get('cache.m')}" (Return "https://example.invalid/cb"))
+                        , ("post", Export "{get('cache.s')}" (Post "https://example.invalid/cb"))
+                        , ("dl", Export "{get('cache.b')}" (Download "tx.cbor"))
+                        , ("qr", Export "{get('cache.u')}" (QR Nothing))
+                        , ("cp", Export "{get('cache.m')}" Copy)
+                        ]
+                , metadata = Nothing
+                }
+    case Aeson.eitherDecode (Aeson.encode s) of
+        Left e -> assertFailure $ "decode failed: " <> e
+        Right s' -> s' @?= s
+
+smartConstructorTags :: TestTree
+smartConstructorTags =
+    testGroup "smart constructors emit the right type tag" $
+        map
+            check
+            [ ("buildTx", buildTxAction "n" (Aeson.Object mempty))
+            , ("signTx", signTxAction "n" "{ref}")
+            , ("signData", signDataAction "n" "addr" "msg")
+            , ("submitTx", submitTxAction "n" "{ref}")
+            , ("getUTxOs", getUTxOsAction "n")
+            ]
+  where
+    check (tag, action) = testCase (T.unpack tag) $
+        case Aeson.toJSON action of
+            Aeson.Object km -> case KeyMap.lookup "type" km of
+                Just (Aeson.String t) -> t @?= tag
+                other -> assertFailure $ "type field missing or wrong: " <> show other
+            other -> assertFailure $ "Action encoded to non-object: " <> show other

--- a/test/golden/build-tx.json
+++ b/test/golden/build-tx.json
@@ -1,0 +1,32 @@
+{
+  "type": "script",
+  "title": "Build and POST a transaction",
+  "run": {
+    "u": {
+      "type": "getUTxOs",
+      "namespace": "cache",
+      "detail": {}
+    },
+    "built": {
+      "type": "buildTx",
+      "namespace": "cache",
+      "detail": {
+        "txOuts": [
+          {
+            "address": "addr_test1qpk...placeholder",
+            "value": {
+              "coin": "1000000"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "exports": {
+    "cbor": {
+      "source": "{get('cache.built.tx')}",
+      "mode": "post",
+      "postUrl": "https://example.invalid/callback"
+    }
+  }
+}

--- a/test/golden/export-copy.json
+++ b/test/golden/export-copy.json
@@ -1,0 +1,20 @@
+{
+  "type": "script",
+  "title": "Export via copy",
+  "run": {
+    "result": {
+      "type": "signData",
+      "namespace": "cache",
+      "detail": {
+        "address": "addr_test1qpk...placeholder",
+        "message": "copy-mode"
+      }
+    }
+  },
+  "exports": {
+    "out": {
+      "source": "{get('cache.result')}",
+      "mode": "copy"
+    }
+  }
+}

--- a/test/golden/export-download.json
+++ b/test/golden/export-download.json
@@ -1,0 +1,21 @@
+{
+  "type": "script",
+  "title": "Export via download",
+  "run": {
+    "result": {
+      "type": "signData",
+      "namespace": "cache",
+      "detail": {
+        "address": "addr_test1qpk...placeholder",
+        "message": "download-mode"
+      }
+    }
+  },
+  "exports": {
+    "out": {
+      "source": "{get('cache.result')}",
+      "mode": "download",
+      "downloadName": "signature.bin"
+    }
+  }
+}

--- a/test/golden/export-post.json
+++ b/test/golden/export-post.json
@@ -1,0 +1,21 @@
+{
+  "type": "script",
+  "title": "Export via post",
+  "run": {
+    "result": {
+      "type": "signData",
+      "namespace": "cache",
+      "detail": {
+        "address": "addr_test1qpk...placeholder",
+        "message": "post-mode"
+      }
+    }
+  },
+  "exports": {
+    "out": {
+      "source": "{get('cache.result')}",
+      "mode": "post",
+      "postUrl": "https://example.invalid/callback"
+    }
+  }
+}

--- a/test/golden/export-qr.json
+++ b/test/golden/export-qr.json
@@ -1,0 +1,20 @@
+{
+  "type": "script",
+  "title": "Export via QR",
+  "run": {
+    "result": {
+      "type": "signData",
+      "namespace": "cache",
+      "detail": {
+        "address": "addr_test1qpk...placeholder",
+        "message": "qr-mode"
+      }
+    }
+  },
+  "exports": {
+    "out": {
+      "source": "{get('cache.result')}",
+      "mode": "qr"
+    }
+  }
+}

--- a/test/golden/export-return.json
+++ b/test/golden/export-return.json
@@ -1,0 +1,21 @@
+{
+  "type": "script",
+  "title": "Export via return",
+  "run": {
+    "result": {
+      "type": "signData",
+      "namespace": "cache",
+      "detail": {
+        "address": "addr_test1qpk...placeholder",
+        "message": "return-mode"
+      }
+    }
+  },
+  "exports": {
+    "out": {
+      "source": "{get('cache.result')}",
+      "mode": "return",
+      "returnUrl": "https://example.invalid/redirect"
+    }
+  }
+}

--- a/test/golden/get-utxos.json
+++ b/test/golden/get-utxos.json
@@ -1,0 +1,17 @@
+{
+  "type": "script",
+  "title": "Fetch wallet UTxOs",
+  "run": {
+    "utxos": {
+      "type": "getUTxOs",
+      "namespace": "cache",
+      "detail": {}
+    }
+  },
+  "exports": {
+    "set": {
+      "source": "{get('cache.utxos')}",
+      "mode": "copy"
+    }
+  }
+}

--- a/test/golden/sign-data.json
+++ b/test/golden/sign-data.json
@@ -1,0 +1,21 @@
+{
+  "type": "script",
+  "title": "Sign a message",
+  "description": "Sign the literal text \"hello\" with the connected wallet.",
+  "run": {
+    "signResult": {
+      "type": "signData",
+      "namespace": "cache",
+      "detail": {
+        "address": "addr_test1qpk...placeholder",
+        "message": "hello"
+      }
+    }
+  },
+  "exports": {
+    "signature": {
+      "source": "{get('cache.signResult')}",
+      "mode": "copy"
+    }
+  }
+}

--- a/test/golden/sign-tx.json
+++ b/test/golden/sign-tx.json
@@ -1,0 +1,20 @@
+{
+  "type": "script",
+  "title": "Sign a pre-built transaction",
+  "run": {
+    "signed": {
+      "type": "signTx",
+      "namespace": "cache",
+      "detail": {
+        "tx": "{get('inputs.unsigned')}"
+      }
+    }
+  },
+  "exports": {
+    "witness": {
+      "source": "{get('cache.signed')}",
+      "mode": "return",
+      "returnUrl": "https://example.invalid/redirect"
+    }
+  }
+}

--- a/test/golden/submit-tx.json
+++ b/test/golden/submit-tx.json
@@ -1,0 +1,20 @@
+{
+  "type": "script",
+  "title": "Submit a signed transaction",
+  "run": {
+    "submitted": {
+      "type": "submitTx",
+      "namespace": "cache",
+      "detail": {
+        "tx": "{get('inputs.signed')}"
+      }
+    }
+  },
+  "exports": {
+    "hash": {
+      "source": "{get('cache.submitted')}",
+      "mode": "post",
+      "postUrl": "https://example.invalid/hash"
+    }
+  }
+}


### PR DESCRIPTION
Tracks ticket [#6](https://github.com/lambdasistemi/haskell-gamechanger/issues/6).

## Status

- [x] Spec
- [x] Plan
- [x] Data model
- [x] Quickstart
- [x] Task list
- [x] Implementation (T001–T034)
- [x] Full local CI (build + tests + format + hlint) green
- [x] CI green on `nixos` runner (Build Gate / Tests / Lint / Docs — all SUCCESS)
- [x] SC-005 wallet verification attempted — deferred to [#7](https://github.com/lambdasistemi/haskell-gamechanger/issues/7) (see note below)

## Artefacts

- [spec.md](https://github.com/lambdasistemi/haskell-gamechanger/blob/002-script-types/specs/002-script-types/spec.md)
- [plan.md](https://github.com/lambdasistemi/haskell-gamechanger/blob/002-script-types/specs/002-script-types/plan.md)
- [data-model.md](https://github.com/lambdasistemi/haskell-gamechanger/blob/002-script-types/specs/002-script-types/data-model.md)
- [quickstart.md](https://github.com/lambdasistemi/haskell-gamechanger/blob/002-script-types/specs/002-script-types/quickstart.md)
- [tasks.md](https://github.com/lambdasistemi/haskell-gamechanger/blob/002-script-types/specs/002-script-types/tasks.md)

## Summary

Typed Haskell records for the GameChanger JSON script protocol with Aeson codec and a `tasty-golden` round-trip harness. This is the published JSON boundary (constitution §8) — the schema shape is load-bearing for every downstream integration.

## Code tour

### [`src/GameChanger/Script/Types.hs`](https://github.com/lambdasistemi/haskell-gamechanger/blob/002-script-types/src/GameChanger/Script/Types.hs)

The wire shape. One record per protocol value, hand-rolled `ToJSON`/`FromJSON` so the field order, optional-field handling, and the flattened `Export` object all match what the wallet accepts byte-for-byte.

- `Script` — top-level `{ type: "script", title, run, exports, description?, metadata? }`. The `type` discriminator is emitted and strictly required on decode (FR-009).
- `Action` — `{ type: ActionKind, namespace, detail? }`. `detail` is `Aeson.Value` at this ticket; typed refinement lands in #9 (Intent compiler).
- `ActionKind` — closed sum over the five wallet-supported kinds (`buildTx`, `signTx`, `signData`, `submitTx`, `getUTxOs`). Decoder rejects unknowns with an explicit error listing the accepted tags.
- `Export` / `Channel` — `Channel` constructors carry per-mode descriptor fields (`Return {returnUrl}`, `Post {postUrl}`, `Download {downloadName}`, `QR {qrOptions}`, `Copy`). `Export`'s `ToJSON` flattens `source`, `mode`, and descriptor into one object; the decoder parses the same flat shape.

### [`src/GameChanger/Script/Smart.hs`](https://github.com/lambdasistemi/haskell-gamechanger/blob/002-script-types/src/GameChanger/Script/Smart.hs)

Five smart constructors — one per action kind. Each fixes the `ActionKind` tag and shapes the minimal `detail` payload (e.g. `signDataAction ns addr message` builds `{ address, message }`). Keeps callers from constructing an `Action` with an inconsistent `kind` / `detail` pair.

### [`src/GameChanger/Script.hs`](https://github.com/lambdasistemi/haskell-gamechanger/blob/002-script-types/src/GameChanger/Script.hs)

Public re-export surface: `Script`, `Action`, `ActionKind (..)`, `Export`, `Channel (..)`, and all five smart constructors. Downstream tickets import this module, not the split files.

### [`test/Golden.hs`](https://github.com/lambdasistemi/haskell-gamechanger/blob/002-script-types/test/Golden.hs)

`tasty-golden` harness. `findByExtension [".json"] "test/golden"` auto-picks up every fixture in the directory; per D5 (plan) adding a fixture is dropping a file. Per D6 each fixture is canonicalised (decode original → decode as `Script` → re-encode → decode again → compare at `Value` level) so key-order and whitespace drift in fixtures are not false failures.

### [`test/golden/`](https://github.com/lambdasistemi/haskell-gamechanger/tree/002-script-types/test/golden)

Ten fixtures covering the full matrix:

- Every `ActionKind`: [`build-tx`](https://github.com/lambdasistemi/haskell-gamechanger/blob/002-script-types/test/golden/build-tx.json), [`sign-tx`](https://github.com/lambdasistemi/haskell-gamechanger/blob/002-script-types/test/golden/sign-tx.json), [`sign-data`](https://github.com/lambdasistemi/haskell-gamechanger/blob/002-script-types/test/golden/sign-data.json), [`submit-tx`](https://github.com/lambdasistemi/haskell-gamechanger/blob/002-script-types/test/golden/submit-tx.json), [`get-utxos`](https://github.com/lambdasistemi/haskell-gamechanger/blob/002-script-types/test/golden/get-utxos.json).
- Every `Channel` mode: [`export-return`](https://github.com/lambdasistemi/haskell-gamechanger/blob/002-script-types/test/golden/export-return.json), [`export-post`](https://github.com/lambdasistemi/haskell-gamechanger/blob/002-script-types/test/golden/export-post.json), [`export-download`](https://github.com/lambdasistemi/haskell-gamechanger/blob/002-script-types/test/golden/export-download.json), [`export-qr`](https://github.com/lambdasistemi/haskell-gamechanger/blob/002-script-types/test/golden/export-qr.json), [`export-copy`](https://github.com/lambdasistemi/haskell-gamechanger/blob/002-script-types/test/golden/export-copy.json).

### [`test/Spec.hs`](https://github.com/lambdasistemi/haskell-gamechanger/blob/002-script-types/test/Spec.hs)

Wires `Golden` into the tasty tree and adds two inline test groups:

- A hand-built `Script` that exercises every action kind and every channel mode, then round-trips through `encode`/`decode` and asserts equality. Catches regressions in the Haskell-level codec that fixtures might miss.
- Per-constructor assertions that each smart constructor emits the expected JSON `type` tag.

17 tests, all green locally (`just ci` = build + test + fourmolu check + cabal-fmt check + hlint).

## Key design calls

- **D1** Plain records, not final-tagless — `Script` is the boundary, not the eDSL.
- **D2** Closed sums for `ActionKind` and `Channel` — decoder rejects unknowns with an explicit error.
- **D3** `detail :: Aeson.Value` for now; typed in #9 when the Intent compiler has the Cardano surface on hand.
- **D5** `tasty-golden`'s `findByExtension` — adding a fixture is dropping a JSON file.
- **D6** Canonicalise via `Value`-level comparison, not raw bytes — decouples fixture stability from whitespace.
- **D8** Split modules: `Script` (surface) → `Script.Types` (records + Aeson) + `Script.Smart` (constructors).

## SC-005 — wallet verification (deferred to #7)

SC-005 requires that a representative fixture be accepted by the live wallet. I drove the beta wallet (`https://beta-wallet.gamechanger.finance/`) and the migrated wallet (`https://wallet.gamechanger.finance/`) headlessly and hit two real findings about the **encoding pipeline**, not the JSON schema:

1. The wallet rejected our URL with *"Failed to decode API call. Unknown decoder header. Cannot decode."*
2. Inspecting a known-good URL from the wallet's own docs shows the payload starts with `5d 00 00 00 02 4d 04 00` — the raw **LZMA1** header, not gzip. And the path is `/api/2/run/`, not `/api/2/tx/`.

The full finding is logged in [issue #7 (GameChanger.Encoding)](https://github.com/lambdasistemi/haskell-gamechanger/issues/7#issuecomment-4281276517) because the encoding pipeline is that ticket's scope — this PR (#6) only owns the types/JSON codec, which never got a chance to be evaluated by the wallet because we were blocked at the compression layer. Once #7 lands with the correct LZMA1 + `/api/2/run/` encoding, end-to-end wallet acceptance of the #6 fixtures will be straightforward to verify.

This matches the speckit contract: SC-005 spans the full stack (types + encoding); the types half passes (local round-trip + golden harness, 17 tests green), the wallet-acceptance half moves to #7 where the bug actually lives.

## Out of scope

- Intent eDSL (#8), compiler (#9), URL encoding (#7), QR rendering (#10), CLI wiring (#11), callback server (#12).
- No `cardano-api` / `cardano-ledger` / `plutus-core` deps (FR-011).

## After merge

Unblocks [#7](https://github.com/lambdasistemi/haskell-gamechanger/issues/7) (Encoding — now has a concrete bug to start from) and [#9](https://github.com/lambdasistemi/haskell-gamechanger/issues/9) (Intent.Compile).