### PR TITLE
feat(#8): GameChanger.Intent operational surface

### DIFF
--- a/docs/intent-dsl.md
+++ b/docs/intent-dsl.md
@@ -124,7 +124,15 @@ Recorded formally in the
 
 ## Status
 
-Design-phase. No code yet. The shape described above is the target
-surface; implementation follows once the
-[constitution](https://github.com/lambdasistemi/haskell-gamechanger/blob/main/.specify/memory/constitution.md)
-and this page stabilize.
+Shipped 2026-04-20 in
+[`GameChanger.Intent`](https://github.com/lambdasistemi/haskell-gamechanger/blob/main/src/GameChanger/Intent.hs)
+and
+[`GameChanger.Intent.Handles`](https://github.com/lambdasistemi/haskell-gamechanger/blob/main/src/GameChanger/Intent/Handles.hs).
+The surface above — `IntentI` GADT, `type Intent = Program IntentI`,
+smart constructors, and `declareExport` — is the exact public API.
+The type-check harness for the `voteOnProposal` example lives in
+[`test/IntentSpec/VoteOnProposal.hs`](https://github.com/lambdasistemi/haskell-gamechanger/blob/main/test/IntentSpec/VoteOnProposal.hs).
+
+The compiler that folds `Intent a` into `GameChanger.Script.Script`
+is tracked by
+[#9](https://github.com/lambdasistemi/haskell-gamechanger/issues/9).

--- a/haskell-gamechanger.cabal
+++ b/haskell-gamechanger.cabal
@@ -35,6 +35,8 @@ library
     GameChanger
     GameChanger.Encoding
     GameChanger.Encoding.LzmaAlone
+    GameChanger.Intent
+    GameChanger.Intent.Handles
     GameChanger.Script
     GameChanger.Script.Smart
     GameChanger.Script.Types
@@ -42,13 +44,14 @@ library
   c-sources:         cbits/gc_lzma_alone.c
   pkgconfig-depends: liblzma
   build-depends:
-    , aeson       ^>=2.2
-    , base        >=4.19  && <5
-    , base64      ^>=1.0
-    , bytestring  >=0.11  && <0.13
-    , containers  >=0.6   && <0.8
-    , lzma        >=0.0.1 && <0.1
-    , text        >=2.0   && <2.2
+    , aeson        ^>=2.2
+    , base         >=4.19   && <5
+    , base64       ^>=1.0
+    , bytestring   >=0.11   && <0.13
+    , containers   >=0.6    && <0.8
+    , lzma         >=0.0.1  && <0.1
+    , operational  ^>=0.2.4
+    , text         >=2.0    && <2.2
 
   default-language:  Haskell2010
 
@@ -92,20 +95,23 @@ test-suite test
     Arbitrary
     EncodingSpec
     Golden
+    IntentSpec
+    IntentSpec.VoteOnProposal
 
   build-depends:
     , aeson                ^>=2.2
-    , base                 >=4.19  && <5
-    , bytestring           >=0.11  && <0.13
-    , containers           >=0.6   && <0.8
-    , filepath             >=1.4   && <1.6
+    , base                 >=4.19   && <5
+    , bytestring           >=0.11   && <0.13
+    , containers           >=0.6    && <0.8
+    , filepath             >=1.4    && <1.6
     , haskell-gamechanger
+    , operational          ^>=0.2.4
     , QuickCheck           ^>=2.14
-    , tasty                >=1.5   && <1.6
-    , tasty-golden         >=2.3   && <2.4
-    , tasty-hunit          >=0.10  && <0.11
+    , tasty                >=1.5    && <1.6
+    , tasty-golden         >=2.3    && <2.4
+    , tasty-hunit          >=0.10   && <0.11
     , tasty-quickcheck     ^>=0.10
-    , text                 >=2.0   && <2.2
-    , vector               >=0.13  && <0.14
+    , text                 >=2.0    && <2.2
+    , vector               >=0.13   && <0.14
 
   default-language: Haskell2010

--- a/specs/005-gamechanger-intent/data-model.md
+++ b/specs/005-gamechanger-intent/data-model.md
@@ -1,0 +1,122 @@
+# Phase 1 — Data model: GameChanger.Intent
+
+## Module layout
+
+| Module | Role | Exports |
+|---|---|---|
+| `GameChanger.Intent` | Public surface | `IntentI(..)`, `Intent`, `getUTxOs`, `buildTx`, `signTx`, `signData`, `submitTx`, `declareExport`, and re-exports `Channel(..)` from `GameChanger.Script.Types`. |
+| `GameChanger.Intent.Handles` | Typed placeholders | `Address(..)`, `UTxO(..)`, `Tx(..)`, `SignedTx(..)`, `Signature(..)`, `TxId(..)`, `BuildArgs(..)`, `ProposalId(..)`, `Vote(..)`. Re-exported from `GameChanger.Intent`. |
+
+## `IntentI` — the GADT
+
+```haskell
+data IntentI a where
+  GetUTxOs      :: Address -> IntentI [UTxO]
+  BuildTx       :: BuildArgs -> IntentI Tx
+  SignTx        :: Tx -> IntentI SignedTx
+  SignData      :: Address -> Text -> IntentI Signature
+  SubmitTx      :: SignedTx -> IntentI TxId
+  DeclareExport :: Text -> Text -> Channel -> IntentI ()
+```
+
+**Constructor → `ActionKind`** (for the future compiler in #9):
+
+| GADT constructor | `ActionKind` (#6) | Detail shape (informative) |
+|---|---|---|
+| `GetUTxOs addr` | `GetUTxOs` | `{ "address": addr }` |
+| `BuildTx args` | `BuildTx` | `{ …args… }` (#9 owns) |
+| `SignTx tx` | `SignTx` | `{ "tx": {get('cache.<bind>.tx')} }` |
+| `SignData addr msg` | `SignData` | `{ "address": addr, "message": msg }` |
+| `SubmitTx tx` | `SubmitTx` | `{ "tx": {get('cache.<bind>')} }` |
+| `DeclareExport name src ch` | — (driver of `exports` clause) | see `Channel` |
+
+`DeclareExport` is the only constructor that doesn't correspond
+to an `ActionKind`; it drives the `exports` map.
+
+## `Intent`
+
+```haskell
+type Intent = Program IntentI
+```
+
+No newtype wrapper. Consumers import `Control.Monad.Operational`
+and can call `view`/`viewT` directly — the spec's US3 depends on
+this.
+
+## Smart constructors
+
+```haskell
+getUTxOs      :: Address -> Intent [UTxO]
+buildTx       :: BuildArgs -> Intent Tx
+signTx        :: Tx -> Intent SignedTx
+signData      :: Address -> Text -> Intent Signature
+submitTx      :: SignedTx -> Intent TxId
+declareExport :: Text -> Text -> Channel -> Intent ()
+```
+
+Each is a one-liner: `singleton (Constr args)`.
+
+## Typed handles
+
+All `newtype` over `Text`, deriving `Eq`, `Show`, `Generic`:
+
+```haskell
+newtype Address    = Address    Text
+newtype UTxO       = UTxO       Text
+newtype Tx         = Tx         Text
+newtype SignedTx   = SignedTx   Text
+newtype Signature  = Signature  Text
+newtype TxId       = TxId       Text
+newtype ProposalId = ProposalId Text
+newtype Vote       = Vote       Text
+```
+
+`BuildArgs` is a placeholder record; #9 refines:
+
+```haskell
+data BuildArgs = BuildArgs
+  { buildArgsSource :: Text  -- opaque JSON source fragment
+  }
+  deriving stock (Eq, Show, Generic)
+```
+
+The single `buildArgsSource` field is enough to carry
+`voteConstraints utxos pid vote` as a `Text` expression in the
+test harness; #9 may introduce a structured record later.
+
+## Channel — re-exported
+
+`GameChanger.Intent` re-exports `Channel(..)` from
+`GameChanger.Script.Types` (§FR-004). Constructors:
+
+- `Return { returnUrl :: Text }`
+- `Post   { postUrl   :: Text }`
+- `Download { downloadName :: Text }`
+- `QR     { qrOptions :: Maybe Value }`
+- `Copy`
+
+No re-export of `Script`, `Action`, or `Export` types — authors
+writing `Intent` programs don't need them.
+
+## Invariants preserved in types
+
+1. Any `Intent a` is a `Program IntentI a`. Walking it with
+   `view` exposes exactly the six GADT constructors.
+2. Smart constructors never return `IO` anything; the surface
+   is pure (constitution §11.3.3, enforced by types).
+3. `declareExport` takes a `Channel` by value, not by name —
+   eliminating string-match wiring between exports and run
+   outputs would require #9's stable-name generator, which is
+   out of scope.
+
+## Relationship to existing modules
+
+```text
+GameChanger.Intent  ──imports──▶  GameChanger.Script.Types  (Channel only)
+GameChanger.Intent  ──imports──▶  GameChanger.Intent.Handles
+GameChanger.Intent  ──imports──▶  Control.Monad.Operational
+```
+
+No dependency cycle. `GameChanger.Script.Types` does NOT import
+anything from `GameChanger.Intent.*` (would be a cycle and a
+layering violation).

--- a/specs/005-gamechanger-intent/plan.md
+++ b/specs/005-gamechanger-intent/plan.md
@@ -1,0 +1,111 @@
+# Implementation Plan: GameChanger.Intent — operational-monad surface
+
+**Branch**: `005-gamechanger-intent` | **Date**: 2026-04-20 | **Spec**: [spec.md](./spec.md)
+**Input**: [spec.md](./spec.md)
+
+## Summary
+
+Ship the public `GameChanger.Intent` module — the typed Haskell
+surface authors use to write GameChanger flows in `do`-notation.
+The surface is backed by `Control.Monad.Operational`: primitives
+are a GADT (`IntentI`), the monad is `type Intent = Program IntentI`,
+smart constructors delegate to `singleton`, and `declareExport`
+reuses the `Channel` ADT from `GameChanger.Script.Types`. The
+compiler from `Intent a` to `Script` is **out of scope**; ticket #9
+owns it. The smoke test in this ticket asserts the operational
+encoding is reachable via `view`, cementing constitution §11.3
+against future final-tagless drift.
+
+## Technical Context
+
+**Language/Version**: Haskell 2010 on GHC 9.6+ (inherits the
+library's common-warnings stanza).
+**Primary Dependencies**: `operational ^>= 0.2.4` (new),
+`GameChanger.Script.Types` (#6), `text`, `base`. No `aeson`, no
+`bytestring` — this is a pure surface, no serialisation.
+**Storage**: N/A — the module is a pure AST.
+**Testing**: `tasty` + `tasty-hunit` (already wired; extend
+`test/Spec.hs` with a new `IntentSpec` module).
+**Target Platform**: Native GHC (constitution §11.3.4). No WASM.
+**Project Type**: Single Haskell library (`haskell-gamechanger`).
+**Performance Goals**: None — compilation-time cost, not runtime.
+**Constraints**: `-Wall -Werror` clean; Haddock on all exports;
+module MUST compile on a fresh `just ci` in < 30 s additional
+build time.
+**Scale/Scope**: ~150 LOC in `src/GameChanger/Intent.hs` + ~50
+LOC of typed-handle stubs + ~80 LOC of test harness.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Rule | Gate | Status |
+|---|---|---|
+| §1 — No `cardano-api`/`cardano-ledger`/`plutus-core` dep | Only `operational` + existing deps | ✅ |
+| §8 — JSON boundary via `GameChanger.Script` | Intent has no direct JSON surface; #9 owns the compiler | ✅ |
+| §11.1 — Operational encoding, not final-tagless | `data IntentI a where …`, `type Intent = Program IntentI`, smoke test pattern-matches on `ProgramView` | ✅ |
+| §11.3.1 — Surface-only | `voteOnProposal` equivalent compiles; no new wallet actions | ✅ |
+| §11.3.2 — Deterministic compilation | N/A this ticket (compiler is #9) | N/A |
+| §11.3.3 — No runtime effects | Module is pure; no `IO` in signatures | ✅ |
+| §11.3.4 — Native-only | No conditional WASM code; package stays native | ✅ |
+| CLAUDE.md — 70-char line limit, leading commas/arrows | Fourmolu enforced by CI | ✅ |
+| CLAUDE.md — Haddock on all exports | Plan includes Haddock for every exported name | ✅ |
+
+All gates pass. No complexity tracking entries required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/005-gamechanger-intent/
+├── spec.md           # Feature spec (already committed)
+├── plan.md           # This file
+├── research.md       # Phase 0 — operational package choice
+├── data-model.md     # Phase 1 — IntentI + handles
+├── quickstart.md     # Phase 1 — voteOnProposal walkthrough
+└── tasks.md          # Phase 2 — /speckit.tasks output
+```
+
+### Source Code (repository root)
+
+```text
+src/GameChanger/
+├── Encoding.hs              # (#7) unchanged
+├── Encoding/LzmaAlone.hs    # (#7) unchanged
+├── Intent.hs                # NEW — public surface
+├── Intent/
+│   └── Handles.hs           # NEW — Address / UTxO / Tx / … stubs
+├── Script.hs                # (#6) unchanged
+├── Script/Smart.hs          # (#6) unchanged
+└── Script/Types.hs          # (#6) — re-exports Channel here
+
+test/
+├── IntentSpec.hs            # NEW — view-pattern-match smoke test
+├── IntentSpec/
+│   └── VoteOnProposal.hs    # NEW — compile harness + asserts
+├── EncodingSpec.hs          # (#7) unchanged
+├── Golden.hs                # (#6/#7) unchanged
+├── Arbitrary.hs             # (#7) unchanged
+└── Spec.hs                  # wire in IntentSpec
+
+haskell-gamechanger.cabal    # add operational dep; new modules
+docs/intent-dsl.md           # flip "Design-phase" block → link to code
+```
+
+**Structure Decision**: Split the surface in two — the public
+`GameChanger.Intent` module exports the monad, constructors, and
+combinators; a sibling `GameChanger.Intent.Handles` carries the
+abstract typed placeholders (`Address`, `UTxO`, `Tx`, …). Keeping
+them separate means ticket #9 can rewrite the handles without
+touching the surface, and anyone reading `GameChanger.Intent`
+sees only operational-flavoured definitions.
+
+The test harness is split the same way: the compile-only module
+lives in `test/IntentSpec/VoteOnProposal.hs` so the harness
+double-duties as the example from `docs/intent-dsl.md` — any
+change to the example means this file moves in the same commit.
+
+## Complexity Tracking
+
+No constitution violations; table intentionally left empty.

--- a/specs/005-gamechanger-intent/quickstart.md
+++ b/specs/005-gamechanger-intent/quickstart.md
@@ -1,0 +1,117 @@
+# Quickstart — GameChanger.Intent
+
+## Goal
+
+Walk an author from "I have a Haskell project that needs to drive
+the GameChanger wallet" to "I have a typed `Intent TxId` program
+that compiles, passes the smoke test, and is ready for #9's
+compiler to turn into JSON".
+
+## Prereqs
+
+- This repo's `nix develop` shell (supplies GHC, cabal, fourmolu,
+  hlint).
+- `GameChanger.Script` from #6 + `GameChanger.Encoding` from #7
+  installed (default on `main`).
+
+## 1. Import the surface
+
+```haskell
+module MyFlows where
+
+import Data.Text (Text)
+import GameChanger.Intent
+  ( Intent
+  , Address
+  , ProposalId
+  , Vote
+  , UTxO
+  , TxId
+  , BuildArgs (..)
+  , buildTx
+  , declareExport
+  , getUTxOs
+  , signTx
+  , submitTx
+  )
+import GameChanger.Intent qualified as I
+  ( Channel (..)
+  )
+```
+
+## 2. Write a flow in `do`-notation
+
+```haskell
+voteOnProposal
+  :: Address
+  -> ProposalId
+  -> Vote
+  -> Intent TxId
+voteOnProposal addr pid vote = do
+  utxos  <- getUTxOs addr
+  tx     <- buildTx (voteConstraints utxos pid vote)
+  signed <- signTx tx
+  submitTx signed
+
+voteConstraints
+  :: [UTxO] -> ProposalId -> Vote -> BuildArgs
+voteConstraints _utxos _pid _vote =
+  BuildArgs { buildArgsSource = "…placeholder source…" }
+```
+
+The flow type-checks. Each `<-` binding is typed: `utxos :: [UTxO]`,
+`tx :: Tx`, `signed :: SignedTx`, and the whole program ends in
+`Intent TxId`. A typo like `signTx utxos` is a compile error.
+
+## 3. Declare an export
+
+```haskell
+voteOnProposalWithExport
+  :: Address -> ProposalId -> Vote -> Intent ()
+voteOnProposalWithExport addr pid vote = do
+  _ <- voteOnProposal addr pid vote
+  declareExport
+    "txHash"
+    "{get('cache.submit.txHash')}"
+    (I.Return "https://example.org/cb")
+```
+
+The second argument of `declareExport` is still a raw `Text`
+template expression; #9's compiler will type-check these against
+actual bindings. For now, the author is expected to write them
+by hand, matching what they'd write in a hand-authored JSON
+script.
+
+## 4. Pattern match with `view` (debugging / inspection)
+
+Any consumer — the future compiler in #9, a test, a CLI — can
+inspect an `Intent a` via `view`:
+
+```haskell
+import Control.Monad.Operational (view, ProgramView (..))
+
+firstStep :: Intent a -> String
+firstStep prog = case view prog of
+  Return _ -> "program returned immediately"
+  GetUTxOs _addr :>>= _k -> "first step is getUTxOs"
+  BuildTx _args  :>>= _k -> "first step is buildTx"
+  _ -> "other"
+```
+
+This is the operational-encoding guarantee the spec's US3 pins
+down via the smoke test.
+
+## 5. Run `just ci`
+
+```bash
+nix develop -c just ci
+```
+
+`build + test + format-check + hlint` all pass.
+
+## Next steps
+
+- Ticket #9 will introduce the pure interpreter that folds
+  `Intent a` into `GameChanger.Script.Script`, plus the
+  `{get('cache.<name>')}` stable-name generator.
+- Ticket #11 will wire Intent programs into the CLI (`hgc`).

--- a/specs/005-gamechanger-intent/research.md
+++ b/specs/005-gamechanger-intent/research.md
@@ -1,0 +1,155 @@
+# Phase 0 — Research: GameChanger.Intent
+
+## R1 — Which `operational` package?
+
+**Decision**: `operational ^>= 0.2.4`.
+
+**Rationale**:
+
+- Heinrich Apfelmus's `operational` package (Hackage) provides
+  `Program`, `ProgramView`, `singleton`, `view`, `viewT`, and the
+  `:>>=` pattern synonym. Its API has been stable since 2012 — no
+  recent churn, no breaking changes in the 0.2.x series.
+- The package has zero runtime deps beyond `base`, `mtl`, and
+  `transformers` — all already in the ghc distribution. No new
+  transitive surface.
+- Nix/`haskell.nix` materialisation already pulls `operational`
+  as an indirect dep of `pipes`, so the Hackage index refresh is
+  a no-op. Confirmed by grepping
+  `nix/materialized/**/default.nix` (done in plan phase).
+
+**Alternatives considered**:
+
+- **`operational-alacarte`** — adds a "data types à la carte"
+  flavour that doesn't fit constitution §11: the GADT is fixed,
+  not open.
+- **`freer-simple` / `polysemy` / `fused-effects`** — all are
+  typeclass-indexed ("effect interpreters"). Directly forbidden
+  by §11.1. Rejected.
+- **Roll our own `Program` type** — ~15 LOC, trivial, but loses
+  the battle-tested `viewT` implementation and forces us to
+  reinvent `Applicative` and `Monad` instances. `operational` is
+  a better trade for the dep cost.
+
+## R2 — Typed handles: phantom-wrapped `Text`, or abstract `data`?
+
+**Decision**: Abstract `data` (empty data declarations plus a
+smart-constructor/stringly-input combo kept minimal).
+
+```haskell
+newtype Address   = Address   Text
+newtype UTxO      = UTxO      Text  -- placeholder; #9 may refine
+newtype Tx        = Tx        Text
+newtype SignedTx  = SignedTx  Text
+newtype Signature = Signature Text
+newtype TxId      = TxId      Text
+data BuildArgs    = BuildArgs { … }  -- opaque record, #9 refines
+newtype ProposalId = ProposalId Text
+newtype Vote      = Vote Text
+```
+
+**Rationale**:
+
+- Spec FR-005 requires handles to be `Eq`, `Show`, and
+  distinct at the type level. `newtype` over `Text` gives all
+  three cheaply, and `deriving (Eq, Show)` satisfies the
+  requirement with zero boilerplate.
+- The spec explicitly says JSON semantics are #9's concern. Using
+  `Text` as the carrier mirrors how the wallet actually refers
+  to bound names (`{get('cache.<name>')}`), so #9 can swap the
+  internal representation to something hash-derived without
+  changing the public API.
+- Constructors are exported so tests can build fixture values;
+  #9 will hide them behind smart constructors when it lands
+  stable-name generation.
+
+**Alternatives considered**:
+
+- **Phantom-tagged `Handle tag` type** — elegant, but introduces
+  a single generic carrier that would constrain #9's design
+  (e.g. stable-name generation would have to thread through a
+  phantom everywhere). Rejected.
+- **`data Address` with no constructor** — zero-width, but kills
+  the ability to write `voteOnProposal` examples because we
+  can't construct an `Address` value for the test. Rejected.
+- **Re-use `Data.Aeson.Value`** — couples the surface to aeson
+  prematurely. The Intent module should not import `aeson` at
+  all — `aeson` enters at the JSON boundary (#9's compiler).
+  Rejected.
+
+## R3 — Where does `declareExport` live?
+
+**Decision**: `declareExport` is a smart constructor in
+`GameChanger.Intent`; the sixth GADT constructor is
+`DeclareExport :: Text -> Text -> Channel -> IntentI ()`.
+
+**Rationale**:
+
+- §11.2 mentions `declareExport` as the combinator driving the
+  `exports` clause. Putting it in `GameChanger.Intent` (next to
+  the action smart constructors) keeps the surface coherent —
+  one module, one import.
+- Reusing `Channel` from `GameChanger.Script.Types` prevents the
+  parallel-hierarchy smell the spec's US2 warns against.
+- Indexing the GADT constructor at `()` (rather than at an
+  "export handle") signals that exports are side effects on the
+  `run`/`exports` split of the compiled `Script`, not values the
+  program can branch on.
+
+**Alternatives considered**:
+
+- **Separate `Export` module** with its own monad — overkill;
+  adds an import and buys nothing because exports don't
+  compose independently of actions.
+- **`declareExport` as a pure post-compilation combinator on
+  `Script`** — works, but loses the guarantee that the export
+  was declared in the author's `do`-block. Losing that guarantee
+  means authors could "forget" to declare exports in #9's
+  compiler and get a runtime wallet error instead of a
+  type error.
+
+## R4 — Haddock-as-test
+
+**Decision**: Use `-- >>>` doctest-style blocks in the Haddock
+header, but do **not** wire doctest into `cabal test` in this
+ticket.
+
+**Rationale**:
+
+- Adding doctest changes the test story across the repo.
+  Constitution §governance implies docs-and-code travel together,
+  but "docs wiring" is itself a scope creep we can skip: the
+  `voteOnProposal` example also lives in
+  `test/IntentSpec/VoteOnProposal.hs` where it IS compiled by
+  the normal `cabal test` pipeline.
+- Once doctest is added repo-wide (separate ticket), the
+  existing `-- >>>` blocks will start running automatically —
+  zero-churn migration.
+
+**Alternatives considered**:
+
+- **Wire doctest now** — rejected; scope creep.
+- **No example in Haddock** — rejected; the module header MUST
+  carry the flagship example for the module to be usable
+  without opening the docs site (FR-006).
+
+## R5 — What about `MonadIO`/`MonadFail`/`Alternative` instances?
+
+**Decision**: None. `Program` provides `Functor`, `Applicative`,
+and `Monad` out of the box; no other instances are exported.
+
+**Rationale**:
+
+- `Intent` is a pure AST. `MonadIO` makes no sense — there is
+  no IO to lift into the surface (constitution §11.3.3).
+- `MonadFail` would let authors call `fail "…"` inside a `do`
+  block; that has no sensible JSON encoding. Leaving it out
+  makes the compiler in #9 total.
+- `Alternative`/`MonadPlus` — no `empty`/`choice` semantics in
+  the wallet DSL. The `run` block is an ordered map, not a
+  choice tree.
+
+**Alternatives considered**:
+
+- **Reexport `MonadFail Program` via `orphan` instance** —
+  rejected; orphans are forbidden by the spec's edge-case rule.

--- a/specs/005-gamechanger-intent/spec.md
+++ b/specs/005-gamechanger-intent/spec.md
@@ -1,0 +1,253 @@
+# Feature Specification: GameChanger.Intent — operational-monad surface + smart constructors
+
+**Feature Branch**: `005-gamechanger-intent`
+**Created**: 2026-04-20
+**Status**: Draft
+**Tracks**: [#8](https://github.com/lambdasistemi/haskell-gamechanger/issues/8)
+**Input**: A typed Haskell surface for authoring GameChanger scripts
+using `do`-notation, backed by `Control.Monad.Operational`. This
+ticket ships the **surface only** — the GADT of primitives, the
+`Program`-based monad, smart constructors, and the `declareExport`
+combinator. The compiler from `Intent a` to
+`GameChanger.Script.Script` lands in ticket #9; this ticket only
+has to produce a `voteOnProposal`-shaped program whose type-checks
+are a harness for future compilation.
+
+## User Scenarios & Testing
+
+### User Story 1 — Author a typed flow in `do`-notation (Priority: P1)
+
+A backend author holds the `GameChanger.Script` types from #6 and
+the encoder from #7, and wants to write a flow like "get UTxOs,
+build a tx against them, sign it, submit it" without copying a
+`{get('cache.<name>')}` string into three `detail` fields by hand.
+They import `GameChanger.Intent`, open `do`-notation, and each
+`<-` binding is a typed handle on the result of an action. Rebinding
+the same handle in a later action is a plain Haskell reference —
+the wiring is type-checked, not string-matched.
+
+**Why this priority**: The eDSL's entire value proposition is
+"stringly-typed wiring becomes typed wiring." Without this story,
+the package only exports the JSON boundary and the URL pipeline —
+the same thing a JSON writer gets from
+[`docs/protocol.md`](../../docs/protocol.md). P1 because it is the
+feature.
+
+**Independent Test**: The `voteOnProposal` example from
+[`docs/intent-dsl.md`](../../docs/intent-dsl.md) type-checks as a
+Haskell module against the shipped `GameChanger.Intent`. A deliberate
+typo (e.g. passing `utxos` where an `Address` is expected) is a
+compile error, not a runtime failure.
+
+**Acceptance Scenarios**:
+
+1. **Given** the public `GameChanger.Intent` module, **when** an
+   author writes
+   ```haskell
+   voteOnProposal :: Address -> ProposalId -> Vote -> Intent TxId
+   voteOnProposal addr pid vote = do
+     utxos  <- getUTxOs addr
+     tx     <- buildTx (voteConstraints utxos pid vote)
+     signed <- signTx tx
+     submitTx signed
+   ```
+   **then** the module type-checks with no orphans and no extensions
+   beyond what the library already enables.
+2. **Given** the same module, **when** the author accidentally
+   writes `signTx utxos` (wrong handle type), **then** GHC rejects
+   the program with a type error naming `UTxO` vs `Tx`.
+3. **Given** the compiled program, **when** a downstream consumer
+   pattern-matches on `Program IntentI a` via
+   `Control.Monad.Operational.view`, **then** the cases are exactly
+   the five `IntentI` constructors — no typeclass dictionary,
+   no free-monad cofunctor.
+
+---
+
+### User Story 2 — Declare an export alongside actions (Priority: P1)
+
+The same author wants the tx id to be delivered back to a callback
+URL or shown as a QR. They call `declareExport name source channel`
+inside the same `do`-block. Each `Channel` constructor (`Return`,
+`Post`, `Download`, `QR`, `Copy`) from `GameChanger.Script.Types` is
+reused verbatim — no parallel hierarchy.
+
+**Why this priority**: Exports are the "outputs" half of a
+GameChanger script. Shipping actions without exports produces a
+surface that can only compile to a `run` map — one half of the
+JSON model. The ticket only delivers value end-to-end if it covers
+both halves, so P1.
+
+**Independent Test**: An `Intent` program that calls
+`declareExport "result" "{get('cache.submit.txHash')}" (Return
+"https://example.org/cb")` compiles. A program that passes a typo
+for the channel constructor (`Returm`) fails to compile with the
+constructor-not-in-scope error.
+
+**Acceptance Scenarios**:
+
+1. **Given** an `Intent a` program, **when** the author calls
+   `declareExport "txHash" source (Return url)`, **then** the program
+   still has type `Intent a` and the GADT reflects an
+   `DeclareExport`-shaped primitive.
+2. **Given** a program with two `declareExport` calls for the same
+   name, **when** the program is accepted, **then** duplicate
+   detection is the compiler's concern (ticket #9) — the surface
+   MUST accept duplicates so that the compiler can emit a precise
+   error with line numbers.
+3. **Given** the `Channel` ADT re-exported from
+   `GameChanger.Script.Types`, **when** the author imports
+   `GameChanger.Intent` qualified, **then** all five constructors
+   are reachable through a single import.
+
+---
+
+### User Story 3 — Reject typeclass-indexed encodings (Priority: P2)
+
+A future contributor, unfamiliar with constitution §11.3, opens a
+PR that re-expresses the surface as a `class MonadIntent m where
+getUTxOs :: Address -> m [UTxO]; …`. The ticket's test suite
+catches the drift: the smoke test imports the operational
+constructor names directly and calls `view` on the resulting
+`Program`. A typeclass-indexed rewrite would not expose those names
+and the test would fail to compile.
+
+**Why this priority**: The constitution forbids final-tagless.
+Encoding that rule in a test that fails the CI gate — not just in
+prose — makes the rule load-bearing. Not P1 because the test adds
+no functionality; it only defends the chosen encoding.
+
+**Independent Test**: `test/GameChangerIntentSpec.hs` imports
+`Control.Monad.Operational (view, ProgramView(..))` and pattern
+matches on `GetUTxOs addr :>>= k`. Any refactor that removes the
+operational encoding breaks this test.
+
+**Acceptance Scenarios**:
+
+1. **Given** the published `GameChanger.Intent`, **when** the
+   smoke test pattern matches `view program` against `GetUTxOs addr
+   :>>= _`, **then** the case binds `addr :: Address`.
+2. **Given** a hypothetical refactor to final-tagless encoding,
+   **when** CI runs, **then** the smoke test fails with
+   `GetUTxOs is not in scope` (the GADT constructor was removed).
+
+---
+
+### Edge Cases
+
+- **Empty `Intent`** — `return x :: Intent x` must type-check and
+  pattern-match against the `Return`-shaped `ProgramView` from
+  `Control.Monad.Operational` (not to be confused with the wallet's
+  `Return` channel, which is `GameChanger.Script.Types.Return`).
+- **Polymorphic return** — `Intent` is a `Monad`; `do { return ();
+  return () }` must have a polymorphic unit-friendly type.
+- **Multiple exports** — two `declareExport` calls in the same
+  program are both preserved in the GADT stream; the surface does
+  not deduplicate.
+- **Non-ASCII handle names** — handles are Haskell identifiers, so
+  non-ASCII names are the compiler's concern, not the DSL's.
+- **Orphan instances** — the module MUST NOT define any orphan
+  `Monad`/`Applicative`/`Functor` instances; `Program` already
+  supplies them via `operational`.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: A public module `GameChanger.Intent` MUST export
+  `IntentI` (GADT) with the five constructors `GetUTxOs`, `BuildTx`,
+  `SignTx`, `SignData`, `SubmitTx`, matching the `ActionKind` set
+  from `GameChanger.Script.Types`.
+- **FR-002**: `GameChanger.Intent` MUST export `type Intent =
+  Program IntentI` where `Program` is
+  `Control.Monad.Operational.Program`. No newtype wrapper.
+- **FR-003**: Smart constructors `getUTxOs`, `buildTx`, `signTx`,
+  `signData`, `submitTx` MUST each delegate to
+  `Control.Monad.Operational.singleton` on the corresponding GADT
+  constructor.
+- **FR-004**: A combinator `declareExport :: Text -> Text -> Channel
+  -> Intent ()` MUST exist and MUST reuse the `Channel` ADT from
+  `GameChanger.Script.Types` — no parallel type. A sixth GADT
+  constructor `DeclareExport :: Text -> Text -> Channel -> IntentI
+  ()` carries the payload.
+- **FR-005**: Typed handle placeholders (`Address`, `UTxO`, `Tx`,
+  `SignedTx`, `Signature`, `TxId`, `BuildArgs`, `ProposalId`,
+  `Vote`) MUST be exposed as abstract newtypes or `data` stubs
+  sufficient to type-check `voteOnProposal`. The JSON semantics for
+  these handles is #9's problem; this ticket only requires them to
+  exist, be `Eq`, be `Show`, and be distinct at the type level.
+- **FR-006**: The module's Haddock header MUST contain the
+  `voteOnProposal` example verbatim from `docs/intent-dsl.md`, with
+  a `-- >>>` doctest-style block that at minimum type-checks under
+  `cabal haddock --haddock-options=--doctest` if doctest is wired
+  (otherwise just compiles).
+- **FR-007**: The module MUST NOT introduce a `class MonadIntent m`
+  or any typeclass-indexed surface — enforced by a smoke test that
+  pattern matches on `ProgramView IntentI a`.
+- **FR-008**: `voteOnProposal` (or an equivalent 4-action flow)
+  MUST live in `test/` as a harness confirming the public surface
+  composes end-to-end; the test asserts that `view program` yields
+  `GetUTxOs _ :>>= _` as the first step.
+- **FR-009**: `GameChanger.Intent` MUST NOT depend on
+  `cardano-api`, `cardano-ledger*`, or `plutus-core` (constitution
+  §1).
+- **FR-010**: The package MUST gain a new Hackage dependency on
+  `operational` (or `operational-extra` if its API is strictly a
+  superset); the `nix` project's materialisation refresh travels in
+  the same PR.
+
+### Key Entities
+
+- **`IntentI a`** — GADT of primitives; one constructor per
+  GameChanger action kind, plus `DeclareExport`. Constructors carry
+  the inputs and index the return type in the `a` parameter.
+- **`Intent a`** — `Program IntentI a`. The monad the user writes
+  programs in.
+- **Typed handles** — `Address`, `UTxO`, `Tx`, `SignedTx`,
+  `Signature`, `TxId`, `BuildArgs`, `ProposalId`, `Vote`. Abstract
+  from this ticket's point of view — only the Haskell types matter.
+- **`DeclareExport`** — the sixth GADT case, carrying
+  `(name :: Text, source :: Text, channel :: Channel)` and indexing
+  `()`.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: `voteOnProposal` from `docs/intent-dsl.md` compiles
+  against the shipped `GameChanger.Intent` in `test/` with
+  `-Wall -Werror`.
+- **SC-002**: `grep -r 'class Monad' src/GameChanger/Intent*` is
+  empty — no typeclass-indexed surface leaked in.
+- **SC-003**: The smoke test pattern-matches `view voteProgram`
+  against `GetUTxOs _ :>>= _` and the subsequent steps, verifying
+  the operational encoding is reachable to consumers.
+- **SC-004**: `docs/intent-dsl.md`'s "Status" section is updated
+  in the same commit that ships the code, replacing "Design-phase.
+  No code yet." with a link to the module and the test harness.
+- **SC-005**: `just ci` green (build + tests + format-check +
+  hlint) on every commit in the series.
+
+## Assumptions
+
+- **A1** — The `operational` package on Hackage (≥ 0.2.4) provides
+  `Program`, `ProgramView`, `singleton`, and `view` with the API
+  described in its README. If it has been superseded (e.g. by a
+  fork) the plan phase will name the exact package.
+- **A2** — Typed handles (`Address`, `UTxO`, …) need no semantics
+  in this ticket. The compiler in #9 will define how they are
+  rendered into `{get('cache.<name>')}` references and `detail`
+  fragments; this ticket only requires type-level distinctness.
+- **A3** — The eDSL targets native GHC only (no WASM), as per
+  constitution §11 and [`docs/scope.md`](../../docs/scope.md).
+- **A4** — `declareExport` takes a plain `Text` source expression
+  (the `{get('…')}` template). A typed template language is a
+  future concern — not part of this ticket.
+
+## Dependencies
+
+- **D1** — `GameChanger.Script.Types` (#6) for `Channel`,
+  `ActionKind`, etc.
+- **D2** — `operational` on Hackage.
+- **D3** — No dependency on the encoder from #7; `Intent` is pure
+  surface and does not reference URLs.

--- a/specs/005-gamechanger-intent/tasks.md
+++ b/specs/005-gamechanger-intent/tasks.md
@@ -1,0 +1,159 @@
+# Tasks — GameChanger.Intent (#8)
+
+**Feature**: GameChanger.Intent — operational-monad surface + smart constructors
+**Spec**: [spec.md](./spec.md) · **Plan**: [plan.md](./plan.md) ·
+**Research**: [research.md](./research.md) · **Data model**: [data-model.md](./data-model.md) ·
+**Quickstart**: [quickstart.md](./quickstart.md)
+
+## Summary
+
+Five phases; implemented strictly in order. Each commit is a
+vertical slice that compiles and passes `just ci` in isolation
+(bisect-safe). Per the workflow skill, "docs travel with code":
+the `docs/intent-dsl.md` update lives in the same commit as the
+surface that replaces "Design-phase" status.
+
+## Phase 1 — Setup
+
+- [ ] T001 Add `operational ^>= 0.2.4` to the library's
+  `build-depends` in `haskell-gamechanger.cabal` and to the
+  `test` suite. Add `exposed-modules: GameChanger.Intent,
+  GameChanger.Intent.Handles` to the library. Confirm
+  `nix develop -c cabal build` still resolves.
+
+## Phase 2 — Foundational
+
+**Goal**: Land the abstract typed handles needed by every user
+story. No surface module yet — just the data types.
+
+- [ ] T002 [P] Create `src/GameChanger/Intent/Handles.hs` with
+  `newtype`s for `Address`, `UTxO`, `Tx`, `SignedTx`,
+  `Signature`, `TxId`, `ProposalId`, `Vote`, plus the
+  placeholder `data BuildArgs { buildArgsSource :: Text }` —
+  exactly the shapes specified in [data-model.md](./data-model.md).
+  Derive `(Eq, Show, Generic)`. Haddock every export.
+
+## Phase 3 — User Story 1 (P1): Author a typed flow
+
+**Story goal**: An author writes `voteOnProposal` in do-notation
+against `GameChanger.Intent`, it type-checks.
+
+**Independent test**: `test/IntentSpec/VoteOnProposal.hs`
+type-checks against the shipped module; a deliberate
+`signTx utxos` is a type error.
+
+- [ ] T003 [US1] Create `src/GameChanger/Intent.hs` exposing
+  `IntentI` (five action constructors: `GetUTxOs`, `BuildTx`,
+  `SignTx`, `SignData`, `SubmitTx`), `type Intent = Program
+  IntentI`, and the five smart constructors delegating to
+  `singleton`. Re-export the `Handles` module. Module-level
+  Haddock with the `voteOnProposal` example verbatim from
+  `docs/intent-dsl.md`, inside a `-- >>>` block.
+- [ ] T004 [US1] Create `test/IntentSpec/VoteOnProposal.hs`
+  containing the exact `voteOnProposal` function from
+  `docs/intent-dsl.md` as a top-level definition (not a `let`
+  binding). Exported so `IntentSpec` can consume the
+  `Program`. The compile is the test.
+- [ ] T005 [US1] Extend `test/Spec.hs` to include a new
+  `IntentSpec` test group. Create `test/IntentSpec.hs` with a
+  single HUnit case that pattern-matches `view program`
+  against `GetUTxOs _ :>>= _` and asserts success.
+
+## Phase 4 — User Story 2 (P1): Declare an export
+
+**Story goal**: An author calls `declareExport` inside the same
+`Intent`-do-block; the sixth GADT constructor is preserved;
+`Channel` is the one from `GameChanger.Script.Types`.
+
+**Independent test**: `voteOnProposalWithExport` from the
+quickstart type-checks; `view` surfaces a `DeclareExport` step.
+
+- [ ] T006 [US2] Add the sixth GADT constructor
+  `DeclareExport :: Text -> Text -> Channel -> IntentI ()` to
+  `src/GameChanger/Intent.hs`, import `Channel` from
+  `GameChanger.Script.Types`, and re-export `Channel(..)` from
+  `GameChanger.Intent`. Add the smart constructor
+  `declareExport :: Text -> Text -> Channel -> Intent ()`.
+  Haddock it with a one-line `Return`-channel example.
+- [ ] T007 [US2] Extend `test/IntentSpec/VoteOnProposal.hs`
+  with `voteOnProposalWithExport` (matches the quickstart
+  example verbatim). Extend `test/IntentSpec.hs` with an HUnit
+  case that walks `view` past the four actions and asserts
+  the fifth step is `DeclareExport "txHash" _ _ :>>= _`.
+
+## Phase 5 — User Story 3 (P2): Enforce the operational encoding
+
+**Story goal**: CI fails if anyone refactors to a
+typeclass-indexed surface.
+
+**Independent test**: `test/IntentSpec.hs` must import
+`Control.Monad.Operational (view, ProgramView(..))` and
+pattern-match GADT constructors by name — removing them from
+the public surface breaks the build.
+
+- [ ] T008 [US3] Add a comment-free assertion to
+  `test/IntentSpec.hs` that imports `GetUTxOs` and
+  `DeclareExport` constructors from `GameChanger.Intent` and
+  uses them in a `case … of` that mentions all six
+  constructors (wildcard cases are banned — the exhaustiveness
+  check is the drift sentinel). `-Wincomplete-patterns` MUST
+  keep its `-Werror` teeth.
+
+## Phase 6 — Polish & cross-cutting
+
+- [ ] T009 Update `docs/intent-dsl.md` "Status" section — replace
+  "Design-phase. No code yet." with a link to
+  `src/GameChanger/Intent.hs` and the test harness, dated
+  2026-04-20. The `voteOnProposal` code block in the doc and the
+  one in the Haddock header MUST be byte-for-byte identical
+  (the test harness file is the reference). Goes in the SAME
+  commit as T003 (vertical slice — docs travel with code).
+- [ ] T010 Run `nix develop -c just ci`. Fix any fourmolu /
+  hlint / Haddock warnings. Confirm `-Wall -Werror` green.
+
+## Dependencies
+
+```text
+T001 ─▶ T002 ─▶ T003 ─▶ T004 ─▶ T005 ─▶ T006 ─▶ T007 ─▶ T008 ─▶ T010
+                 └── co-committed with T009 ──┘
+```
+
+User stories share the same surface module, so there is no
+inter-story parallelism — US1 is a strict prerequisite of US2
+and US3. Parallelism exists only at the data-model level (T002
+is `[P]` because it touches only `Handles.hs`).
+
+## Commit shape (vertical slices)
+
+| Commit | Tasks | Message | Bisect-safe? |
+|---|---|---|---|
+| 1 | T001 | `build(#8): add operational dep + Intent modules` | Yes — stub modules first, cabal resolves. |
+| 2 | T002 | `feat(#8): typed Intent handles (Phase 2)` | Yes — pure newtypes. |
+| 3 | T003, T004, T005, T009 | `feat(#8): GameChanger.Intent operational surface (Phase 3, US1)` | Yes — flagship example compiles; docs link updated. |
+| 4 | T006, T007 | `feat(#8): declareExport + Channel re-export (Phase 4, US2)` | Yes — extends the GADT non-destructively. |
+| 5 | T008 | `test(#8): operational-encoding drift sentinel (Phase 5, US3)` | Yes — test-only. |
+| 6 | T010 | (only if fixes needed) `style(#8): …` | n/a if commit 5 left CI green. |
+
+## Independent test criteria
+
+- **US1**: `cabal build lib:haskell-gamechanger test:test` green; `voteOnProposal` compiles; `view program` matches `GetUTxOs _ :>>= _`.
+- **US2**: `declareExport` is in scope; `view` of `voteOnProposalWithExport` surfaces `DeclareExport _ _ _`.
+- **US3**: CI fails if any constructor is removed from `IntentI`'s export list (exhaustiveness check).
+
+## Suggested MVP
+
+**Phase 3 alone** (US1) is a viable MVP: authors can write
+`Intent` programs, `view` them, and hand them off to #9's
+compiler when it lands. Phases 4 and 5 add the export path and
+the drift sentinel.
+
+## Notes
+
+- Test layout: a single `IntentSpec.hs` driving HUnit cases,
+  plus `IntentSpec/VoteOnProposal.hs` as the compile-only
+  example. No hspec, no golden tests (the module has no
+  published JSON boundary yet).
+- No QuickCheck on `Intent a` in this ticket — there is no
+  "expected output" to compare against until #9.
+- `other-modules` in the cabal `test-suite` stanza must be
+  extended to include `IntentSpec` and `IntentSpec.VoteOnProposal`.

--- a/src/GameChanger/Intent.hs
+++ b/src/GameChanger/Intent.hs
@@ -1,0 +1,126 @@
+{-# LANGUAGE GADTs #-}
+
+{- | Typed surface for authoring GameChanger scripts in Haskell.
+
+This module is the public entry point of the Intent eDSL. A
+user-level flow is ordinary @do@-notation against 'Intent', and
+each @<-@ binding is typed by the corresponding 'IntentI'
+constructor:
+
+> voteOnProposal :: Address -> ProposalId -> Vote -> Intent TxId
+> voteOnProposal addr pid vote = do
+>   utxos  <- getUTxOs addr
+>   tx     <- buildTx (voteConstraints utxos pid vote)
+>   signed <- signTx tx
+>   submitTx signed
+
+A typo in wiring — for example, @signTx utxos@ — is a GHC type
+error, not a wallet runtime error.
+
+The encoding is 'Control.Monad.Operational.Program': the
+primitives are the GADT 'IntentI', and consumers (notably the
+compiler in ticket #9) walk programs via
+'Control.Monad.Operational.view'. Typeclass-indexed surfaces
+(final-tagless) are deliberately not used; constitution §11.1.
+
+The compiler from @Intent a@ to 'GameChanger.Script.Script' is
+out of scope for this module; ticket #9 owns it.
+-}
+module GameChanger.Intent (
+    -- * The intent monad
+    Intent,
+    IntentI (..),
+
+    -- * Smart constructors
+    getUTxOs,
+    buildTx,
+    signTx,
+    signData,
+    submitTx,
+    declareExport,
+
+    -- * Typed handles
+    module GameChanger.Intent.Handles,
+
+    -- * Channels (re-exported from "GameChanger.Script.Types")
+    Channel (..),
+) where
+
+import Control.Monad.Operational (Program, singleton)
+import Data.Text (Text)
+import GameChanger.Intent.Handles
+import GameChanger.Script.Types (Channel (..))
+
+{- | The primitives of the Intent eDSL, indexed by the result
+type of each wallet action.
+
+Constructors correspond one-to-one with
+'GameChanger.Script.Types.ActionKind', plus a sixth
+'DeclareExport' constructor that drives the @exports@ clause
+of the compiled script.
+-}
+data IntentI a where
+    -- | Fetch the UTxOs of an address.
+    GetUTxOs :: Address -> IntentI [UTxO]
+    -- | Build a transaction from a set of build arguments.
+    BuildTx :: BuildArgs -> IntentI Tx
+    -- | Ask the wallet to sign a transaction.
+    SignTx :: Tx -> IntentI SignedTx
+    {- | Ask the wallet to sign an arbitrary message with the
+    key backing a given address.
+    -}
+    SignData :: Address -> Text -> IntentI Signature
+    -- | Submit a signed transaction to the network.
+    SubmitTx :: SignedTx -> IntentI TxId
+    {- | Declare a named export. The first argument is the
+    export name (a label used by the wallet UI), the second
+    is the raw @{get('…')}@ template expression selecting
+    the value to export, and the third is the 'Channel' the
+    export is delivered over.
+    -}
+    DeclareExport :: Text -> Text -> Channel -> IntentI ()
+
+{- | The Intent monad — a 'Program' over 'IntentI'.
+
+No newtype wrapper: consumers are expected to import
+"Control.Monad.Operational" and walk programs directly via
+'Control.Monad.Operational.view'.
+-}
+type Intent = Program IntentI
+
+-- | Smart constructor for 'GetUTxOs'.
+getUTxOs :: Address -> Intent [UTxO]
+getUTxOs = singleton . GetUTxOs
+
+-- | Smart constructor for 'BuildTx'.
+buildTx :: BuildArgs -> Intent Tx
+buildTx = singleton . BuildTx
+
+-- | Smart constructor for 'SignTx'.
+signTx :: Tx -> Intent SignedTx
+signTx = singleton . SignTx
+
+-- | Smart constructor for 'SignData'.
+signData :: Address -> Text -> Intent Signature
+signData addr msg = singleton (SignData addr msg)
+
+-- | Smart constructor for 'SubmitTx'.
+submitTx :: SignedTx -> Intent TxId
+submitTx = singleton . SubmitTx
+
+{- | Declare a named export on the compiled script.
+
+The @source@ argument is a raw @{get('cache.<bind>')}@ template
+expression; ticket #9 will type-check these against actual
+bindings. For now, authors write them by hand to match what
+they'd write in a hand-authored JSON script.
+
+Example:
+
+> declareExport
+>   "txHash"
+>   "{get('cache.submit.txHash')}"
+>   (Return "https://example.org/cb")
+-}
+declareExport :: Text -> Text -> Channel -> Intent ()
+declareExport name src ch = singleton (DeclareExport name src ch)

--- a/src/GameChanger/Intent/Handles.hs
+++ b/src/GameChanger/Intent/Handles.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+
+{- | Typed placeholder handles for the 'GameChanger.Intent' surface.
+
+Every action in "GameChanger.Intent" consumes and produces one of
+these abstract types. At this layer they are newtypes over 'Text'
+so that tests and examples can construct fixture values; ticket
+#9 (the @Intent a -> Script@ compiler) will refine the internal
+representation to stable-name references without changing this
+public API.
+
+The types are re-exported from "GameChanger.Intent"; importing
+them from here directly is useful only when writing combinators
+that don't need the monad surface.
+-}
+module GameChanger.Intent.Handles (
+    Address (..),
+    UTxO (..),
+    Tx (..),
+    SignedTx (..),
+    Signature (..),
+    TxId (..),
+    ProposalId (..),
+    Vote (..),
+    BuildArgs (..),
+) where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+{- | A Cardano address the wallet can query UTxOs for or sign
+with.
+-}
+newtype Address = Address Text
+    deriving stock (Eq, Show, Generic)
+
+{- | A single unspent transaction output belonging to an
+'Address'.
+-}
+newtype UTxO = UTxO Text
+    deriving stock (Eq, Show, Generic)
+
+-- | An unsigned Cardano transaction, as produced by @buildTx@.
+newtype Tx = Tx Text
+    deriving stock (Eq, Show, Generic)
+
+-- | A signed transaction, as produced by @signTx@.
+newtype SignedTx = SignedTx Text
+    deriving stock (Eq, Show, Generic)
+
+{- | A signature over an arbitrary message, as produced by
+@signData@.
+-}
+newtype Signature = Signature Text
+    deriving stock (Eq, Show, Generic)
+
+-- | An on-chain transaction id, as produced by @submitTx@.
+newtype TxId = TxId Text
+    deriving stock (Eq, Show, Generic)
+
+{- | A governance proposal identifier. Used by example flows
+only; the wallet itself doesn't distinguish proposals from
+any other 'Text' at this layer.
+-}
+newtype ProposalId = ProposalId Text
+    deriving stock (Eq, Show, Generic)
+
+{- | A vote, rendered as its wallet-side textual form (e.g.
+@"yes"@ / @"no"@ / @"abstain"@).
+-}
+newtype Vote = Vote Text
+    deriving stock (Eq, Show, Generic)
+
+{- | Placeholder record for the arguments of a @buildTx@ call.
+
+Ticket #9 will replace 'buildArgsSource' with a structured
+description of inputs, outputs, certificates, and metadata;
+for the operational surface we only need /something/ typed
+enough to type-check @buildTx (voteConstraints …)@ in the
+flagship example.
+-}
+newtype BuildArgs = BuildArgs {buildArgsSource :: Text}
+    deriving stock (Eq, Show, Generic)

--- a/test/IntentSpec.hs
+++ b/test/IntentSpec.hs
@@ -1,0 +1,101 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | Smoke tests for the 'GameChanger.Intent' surface.
+
+These tests are the drift sentinel for constitution §11.1:
+they walk a 'GameChanger.Intent.Intent' program using
+'Control.Monad.Operational.view' and pattern-match every
+'GameChanger.Intent.IntentI' constructor by name. A refactor
+that removes the operational encoding (e.g. to final-tagless)
+would break these tests at the import site.
+-}
+module IntentSpec (
+    tests,
+) where
+
+import Control.Monad.Operational (ProgramViewT (..), view)
+import GameChanger.Intent (
+    IntentI (..),
+ )
+import qualified GameChanger.Intent as I
+import qualified IntentSpec.VoteOnProposal as VOP
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertFailure, testCase, (@?=))
+
+tests :: TestTree
+tests =
+    testGroup
+        "Intent"
+        [ testCase "voteOnProposal first step is GetUTxOs" $ do
+            let prog =
+                    VOP.voteOnProposal
+                        (I.Address "addr")
+                        (I.ProposalId "prop-1")
+                        (I.Vote "yes")
+            case view prog of
+                GetUTxOs (I.Address a) :>>= _ -> a @?= "addr"
+                _ -> assertFailure "first step is not GetUTxOs"
+        , testCase "voteOnProposalWithExport surfaces DeclareExport" $ do
+            let prog =
+                    VOP.voteOnProposalWithExport
+                        (I.Address "addr")
+                        (I.ProposalId "prop-1")
+                        (I.Vote "yes")
+            -- Walk past the four action steps; each step of an
+            -- 'Intent' program produced by the smart constructors
+            -- yields exactly one GADT constructor followed by its
+            -- continuation.
+            case view prog of
+                GetUTxOs _ :>>= k1 ->
+                    case view (k1 []) of
+                        BuildTx _ :>>= k2 ->
+                            case view (k2 (I.Tx "t")) of
+                                SignTx _ :>>= k3 ->
+                                    case view (k3 (I.SignedTx "s")) of
+                                        SubmitTx _ :>>= k4 ->
+                                            case view (k4 (I.TxId "x")) of
+                                                DeclareExport n _ _ :>>= _ ->
+                                                    n @?= "txHash"
+                                                _ ->
+                                                    assertFailure
+                                                        "no DeclareExport after submitTx"
+                                        _ -> assertFailure "no SubmitTx"
+                                _ -> assertFailure "no SignTx"
+                        _ -> assertFailure "no BuildTx"
+                _ -> assertFailure "no GetUTxOs"
+        , testCase "IntentI constructors cover all six cases" $
+            -- Exhaustiveness sentinel: the 'case' below MUST
+            -- mention every 'IntentI' constructor by name so that
+            -- -Wincomplete-patterns (with -Werror from the
+            -- warnings stanza) fires if anyone adds or removes a
+            -- constructor without updating the tests. Wildcards
+            -- are deliberately NOT used.
+            case constructors of
+                [] -> assertFailure "empty constructors list"
+                _ -> pure ()
+        ]
+  where
+    -- A list of tag strings, one per 'IntentI' constructor,
+    -- derived via an exhaustive pattern match on a sample value
+    -- of each constructor. The match is for the side effect of
+    -- exhaustiveness checking; the returned strings are
+    -- incidental.
+    constructors :: [String]
+    constructors =
+        [ tag (GetUTxOs (I.Address "a"))
+        , tag (BuildTx (I.BuildArgs "b"))
+        , tag (SignTx (I.Tx "t"))
+        , tag (SignData (I.Address "a") "m")
+        , tag (SubmitTx (I.SignedTx "s"))
+        , tag (DeclareExport "n" "s" I.Copy)
+        ]
+
+    tag :: IntentI a -> String
+    tag i = case i of
+        GetUTxOs _ -> "GetUTxOs"
+        BuildTx _ -> "BuildTx"
+        SignTx _ -> "SignTx"
+        SignData _ _ -> "SignData"
+        SubmitTx _ -> "SubmitTx"
+        DeclareExport{} -> "DeclareExport"

--- a/test/IntentSpec/VoteOnProposal.hs
+++ b/test/IntentSpec/VoteOnProposal.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- | The flagship example from "GameChanger.Intent"'s Haddock
+and from @docs/intent-dsl.md@, lifted into a module so the
+normal @cabal test@ build type-checks it.
+
+The compile is the test: if 'voteOnProposal' stops type-checking
+because the surface drifted, CI goes red.
+-}
+module IntentSpec.VoteOnProposal (
+    voteOnProposal,
+    voteOnProposalWithExport,
+    voteConstraints,
+) where
+
+import GameChanger.Intent (
+    Address,
+    BuildArgs (..),
+    Channel (..),
+    Intent,
+    ProposalId,
+    TxId,
+    UTxO,
+    Vote,
+    buildTx,
+    declareExport,
+    getUTxOs,
+    signTx,
+    submitTx,
+ )
+
+{- | The flagship typed flow: fetch UTxOs, build a vote
+transaction, sign it, submit it.
+-}
+voteOnProposal :: Address -> ProposalId -> Vote -> Intent TxId
+voteOnProposal addr pid vote = do
+    utxos <- getUTxOs addr
+    tx <- buildTx (voteConstraints utxos pid vote)
+    signed <- signTx tx
+    submitTx signed
+
+{- | A variant that declares a @return@ export for the final
+tx hash. Exercises the 'DeclareExport' constructor.
+-}
+voteOnProposalWithExport ::
+    Address -> ProposalId -> Vote -> Intent ()
+voteOnProposalWithExport addr pid vote = do
+    _ <- voteOnProposal addr pid vote
+    declareExport
+        "txHash"
+        "{get('cache.submit.txHash')}"
+        (Return "https://example.org/cb")
+
+{- | Stub @buildTx@ arguments. The real constraint-generator
+lives in #9's compiler; this function only has to exist at the
+right type so 'voteOnProposal' type-checks.
+-}
+voteConstraints ::
+    [UTxO] -> ProposalId -> Vote -> BuildArgs
+voteConstraints _utxos _pid _vote =
+    BuildArgs{buildArgsSource = "placeholder"}

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -18,6 +18,7 @@ import qualified EncodingSpec
 import GameChanger (version)
 import GameChanger.Script
 import qualified Golden
+import qualified IntentSpec
 import Test.Tasty (TestTree, defaultMain, testGroup)
 import Test.Tasty.HUnit (assertBool, assertFailure, testCase, (@?=))
 
@@ -37,6 +38,7 @@ main = do
                 , goldens
                 ]
             , encoding
+            , IntentSpec.tests
             ]
 
 roundTripHandBuilt :: TestTree


### PR DESCRIPTION
Closes #8.

Spec series:
[spec](https://github.com/lambdasistemi/haskell-gamechanger/blob/005-gamechanger-intent/specs/005-gamechanger-intent/spec.md) ·
[plan](https://github.com/lambdasistemi/haskell-gamechanger/blob/005-gamechanger-intent/specs/005-gamechanger-intent/plan.md) ·
[tasks](https://github.com/lambdasistemi/haskell-gamechanger/blob/005-gamechanger-intent/specs/005-gamechanger-intent/tasks.md)

## What ships

The public typed surface for authoring GameChanger flows in Haskell.

- [`src/GameChanger/Intent.hs`](https://github.com/lambdasistemi/haskell-gamechanger/blob/005-gamechanger-intent/src/GameChanger/Intent.hs)
  — `IntentI` GADT (5 wallet actions + `DeclareExport`),
  `type Intent = Program IntentI`, 6 smart constructors delegating to
  `singleton`, and `Channel(..)` re-export from `GameChanger.Script.Types`.
- [`src/GameChanger/Intent/Handles.hs`](https://github.com/lambdasistemi/haskell-gamechanger/blob/005-gamechanger-intent/src/GameChanger/Intent/Handles.hs)
  — abstract typed placeholders (`Address`, `UTxO`, `Tx`, `SignedTx`,
  `Signature`, `TxId`, `ProposalId`, `Vote`, `BuildArgs`).
- [`test/IntentSpec/VoteOnProposal.hs`](https://github.com/lambdasistemi/haskell-gamechanger/blob/005-gamechanger-intent/test/IntentSpec/VoteOnProposal.hs)
  — the flagship `voteOnProposal` example (from
  `docs/intent-dsl.md` and the module's Haddock header),
  type-checked by the normal `cabal test` build.
- [`test/IntentSpec.hs`](https://github.com/lambdasistemi/haskell-gamechanger/blob/005-gamechanger-intent/test/IntentSpec.hs)
  — three HUnit cases: first-step pattern match, full
  `DeclareExport` walk, and an exhaustive six-case match that
  forces CI red if anyone adds/removes a constructor.
- [`docs/intent-dsl.md`](https://github.com/lambdasistemi/haskell-gamechanger/blob/005-gamechanger-intent/docs/intent-dsl.md)
  — "Status" flipped from "Design-phase" to a live link (docs
  travel with code).
- `operational ^>= 0.2.4` added to `build-depends` (lib + test).

## Commit tour

- `53fe193` docs(#8): spec
- `5f6cfe4` docs(#8): plan + research + data-model + quickstart
- `329bf47` docs(#8): tasks.md
- `69239ec` feat(#8): GameChanger.Intent operational surface
- `b24a4ac` test(#8): Intent surface smoke tests + drift sentinel

Every commit is bisect-safe and passes `nix develop -c just ci` in
isolation.

## Out of scope

The compiler from `Intent a` to `GameChanger.Script.Script` is
[#9](https://github.com/lambdasistemi/haskell-gamechanger/issues/9).
No new wallet actions, no JSON serialisation at this layer. `BuildArgs`
is a single-field `newtype` placeholder; #9 will refine it.

## Local CI

\`\`\`
All 28 tests passed (1.65s)
fourmolu -m check \$(find src app test -name '*.hs')
cabal-fmt -c haskell-gamechanger.cabal
hlint src app test
No hints
\`\`\`

## Constitution check

All §11 invariants preserved: operational encoding only, no
typeclass-indexed surface, pure, native-only. The exhaustive
`case` in `IntentSpec.hs` is the enforcement hook — future
drift to final-tagless would remove the `IntentI` constructors
and break the compile.