### PR TITLE
Use shared static preview action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,14 +5,21 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, closed]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   build-gate:
     name: Build Gate
+    if: github.event_name != 'pull_request' || github.event.action != 'closed'
     runs-on: nixos
     steps:
       - uses: actions/checkout@v4
@@ -69,40 +76,18 @@ jobs:
       - name: Build docs
         run: nix develop --quiet -c just build-docs
 
-      - name: Deploy PR preview to Surge
+      - name: Publish PR preview
         if: github.event_name == 'pull_request'
-        run: |
-          nix develop --quiet -c npx --yes surge \
-            ./site \
-            ${{ github.repository_owner }}-${{ github.event.repository.name }}-pr-${{ github.event.number }}.surge.sh \
-            --token ${{ secrets.SURGE_TOKEN }}
-
-      - name: Comment preview URL on PR
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: paolino/dev-assets/static-preview@main
         with:
-          script: |
-            const url = `https://${context.repo.owner}-${context.repo.repo}-pr-${context.issue.number}.surge.sh`;
-            const marker = '<!-- surge-preview-url -->';
-            const body = `${marker}\n📄 Docs preview: ${url}`;
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.find(c => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
+          path: site
+          comment-marker: "<!-- docs-preview-url -->"
+
+  pr-preview-cleanup:
+    name: Remove PR Preview
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: nixos
+    steps:
+      - uses: paolino/dev-assets/static-preview@main
+        with:
+          mode: cleanup

--- a/specs/001-haskell-project-skeleton/spec.md
+++ b/specs/001-haskell-project-skeleton/spec.md
@@ -74,15 +74,15 @@ The flake exposes: `packages.<system>.default` (the executable), `devShells.<sys
 
 ### User Story 5 — Docs CI stays green after the skeleton lands (Priority: P2)
 
-The existing `Docs (strict build + PR preview)` workflow continues to pass with no changes. The skeleton does not break the doc site, the surge preview deploys correctly on PRs, and `mkdocs build --strict` remains part of the PR gate set.
+The existing `Docs (strict build + PR preview)` workflow continues to pass with no changes. The skeleton does not break the doc site, the shared preview deploys correctly on PRs, and `mkdocs build --strict` remains part of the PR gate set.
 
 **Why this priority**: the current CI has exactly two jobs (Build Gate stub + Docs). This ticket replaces the Build Gate stub with real substance; it must not collaterally break Docs.
 
-**Independent Test**: open the PR for this ticket, confirm both CI checks remain green and the surge preview renders the existing site.
+**Independent Test**: open the PR for this ticket, confirm both CI checks remain green and the shared preview renders the existing site.
 
 **Acceptance Scenarios**:
 
-1. **Given** the PR for this ticket, **When** CI runs, **Then** the Docs check is green and a surge URL is posted as a sticky comment.
+1. **Given** the PR for this ticket, **When** CI runs, **Then** the Docs check is green and a shared preview URL is posted as a sticky comment.
 2. **Given** the PR is merged, **When** the deploy-docs workflow runs on main, **Then** the GitHub Pages site at `lambdasistemi.github.io/haskell-gamechanger` updates without error.
 
 ---

--- a/specs/001-haskell-project-skeleton/tasks.md
+++ b/specs/001-haskell-project-skeleton/tasks.md
@@ -124,12 +124,12 @@ Single-package cabal project at the repo root. Haskell under `src/`, `app/`, `te
 
 ## Phase 7: User Story 5 — Docs CI stays green (P2)
 
-**Goal**: the existing `deploy-docs.yml` workflow still runs and passes on the PR; the surge preview deploys as before.
+**Goal**: the existing `deploy-docs.yml` workflow still runs and passes on the PR; the shared preview deploys as before.
 
-**Independent test**: open the PR, check the `Docs (strict build + PR preview)` check and the surge sticky-comment URL.
+**Independent test**: open the PR, check the `Docs (strict build + PR preview)` check and the shared preview sticky-comment URL.
 
 - [ ] T028 [US5] Confirm `.github/workflows/deploy-docs.yml` is unchanged by this branch's diff.
-- [ ] T029 [US5] After pushing, confirm the Docs check is green on the PR and that a surge preview URL appears as a sticky comment.
+- [ ] T029 [US5] After pushing, confirm the Docs check is green on the PR and that a shared preview URL appears as a sticky comment.
 - [ ] T030 [US5] Manually browse the preview URL and verify the Scope / Intent eDSL / Protocol pages render.
 
 **Checkpoint**: Story 5 green.


### PR DESCRIPTION
## Summary
- replace Surge PR docs previews with the reusable `paolino/dev-assets/static-preview` action
- keep the existing docs build and use the shared action for PR comments
- add closed-PR cleanup and refresh stale spec wording

## Verification
- `nix run nixpkgs#actionlint -- -ignore 'label "nixos" is unknown' .github/workflows/ci.yml .github/workflows/deploy-docs.yml`\n- `nix develop --quiet -c just build-docs`\n- `git diff --check`\n- `rg -n "surge|SURGE|surge\\.sh" /code/haskell-gamechanger-shared-preview`